### PR TITLE
Remove -staging part from Demo and Prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "config": {
     "demo": {
-      "cosUrl": "http://div-cos-demo-staging.service.core-compute-demo.internal",
+      "cosUrl": "http://div-cos-demo.service.core-compute-demo.internal",
       "ccdUrl": "http://ccd-data-store-api-demo.service.core-compute-demo.internal"
     },
     "aat": {
@@ -20,7 +20,7 @@
       "ccdUrl": "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     },
     "prod": {
-      "cosUrl": "http://div-cos-prod-staging.service.core-compute-prod.internal",
+      "cosUrl": "http://div-cos-prod.service.core-compute-prod.internal",
       "ccdUrl": "http://ccd-data-store-api-prod.service.core-compute-prod.internal"
     }
   },


### PR DESCRIPTION
Only AAT runs the Integration Test that requires the -staging url.
For Demo and Prod it is best to use the actual prod slot app for callbacks.

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
