### PR TITLE
Add Certificate of Entitlement Doc Type

### DIFF
--- a/definitions/divorce/json/FixedLists.json
+++ b/definitions/divorce/json/FixedLists.json
@@ -242,6 +242,12 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "d8documentsReceivedEnum",
+    "ListElementCode": "coe",
+    "ListElement": "Certificate Of Entitlement"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "d8documentsReceivedEnum",
     "ListElementCode": "coRespondentAnswers",
     "ListElement": "Co-Respondent Answers"
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DIV-4859 - Add Certificate of Entitlement Document Type Enum](https://tools.hmcts.net/jira/browse/DIV-4859)

Adds the required Document Type enum for Certificate of Entitlement.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
