### PR TITLE
Div 3503 solicitior co resp tab missing

### DIFF
--- a/definitions/divorce/json/CaseRoles.json
+++ b/definitions/divorce/json/CaseRoles.json
@@ -1,0 +1,8 @@
+[
+  {
+    "CaseTypeID": "DIVORCE",
+    "ID": "[RESPSOLICITOR]",
+    "Name": "resp-solicitor",
+    "Description": "Respondent Solicitor"
+  }
+]

--- a/definitions/divorce/json/CaseRoles.json
+++ b/definitions/divorce/json/CaseRoles.json
@@ -1,8 +1,0 @@
-[
-  {
-    "CaseTypeID": "DIVORCE",
-    "ID": "[RESPSOLICITOR]",
-    "Name": "resp-solicitor",
-    "Description": "Respondent Solicitor"
-  }
-]

--- a/definitions/divorce/json/CaseType.json
+++ b/definitions/divorce/json/CaseType.json
@@ -2,7 +2,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "DIVORCE",
-    "Name": "Divorce case - v113.17",
+    "Name": "Divorce case - v113.18",
     "Description": "Handling of the dissolution of marriage",
     "JurisdictionID": "DIVORCE",
     "PrintableDocumentsUrl": "${CCD_DEF_CCD_URL}/callback/jurisdictions/DIVORCE/case-types/DIVORCE/documents",

--- a/definitions/divorce/json/CaseTypeTab.json
+++ b/definitions/divorce/json/CaseTypeTab.json
@@ -1849,7 +1849,7 @@
     "TabDisplayOrder": 3,
     "CaseFieldID": "D8caseReference",
     "TabFieldDisplayOrder": 1,
-    "TabShowCondition": "D8ReasonForDivorce=\"adultery\" AND D8ReasonForDivorceAdulteryWishToName=\"Y*\""
+    "TabShowCondition": "D8ReasonForDivorce=\"adultery\" AND (D8ReasonForDivorceAdulteryWishToName=\"Y*\" OR D8ReasonForDivorceAdulteryIsNamed=\"Y*\")"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/divorce/json/CaseTypeTab.json
+++ b/definitions/divorce/json/CaseTypeTab.json
@@ -1142,6 +1142,17 @@
     "TabID": "facts",
     "TabLabel": "Reason for divorce",
     "TabDisplayOrder": 5,
+    "CaseFieldID": "D8ReasonForDivorceAdulteryIsNamed",
+    "TabFieldDisplayOrder": 2,
+    "FieldShowCondition": "D8ReasonForDivorce=\"adultery\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "facts",
+    "TabLabel": "Reason for divorce",
+    "TabDisplayOrder": 5,
     "CaseFieldID": "D8ReasonForDivorceAdulteryDetails",
     "TabFieldDisplayOrder": 3,
     "FieldShowCondition": "D8ReasonForDivorce=\"adultery\""
@@ -1849,7 +1860,7 @@
     "TabDisplayOrder": 3,
     "CaseFieldID": "D8caseReference",
     "TabFieldDisplayOrder": 1,
-    "TabShowCondition": "D8ReasonForDivorce=\"adultery\" AND (D8ReasonForDivorceAdulteryWishToName=\"Y*\" OR D8ReasonForDivorceAdulteryIsNamed=\"Y*\")"
+    "TabShowCondition": "D8ReasonForDivorce=\"adultery\" AND D8ReasonForDivorceAdulteryWishToName=\"Y*\""
   },
   {
     "LiveFrom": "01/01/2017",
@@ -2075,12 +2086,232 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "Channel": "CaseWorker",
-    "TabID": "coRespondent",
+    "TabID": "SolicitorCoRespondent",
     "TabLabel": "Co-Respondent",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "D8ReasonForDivorceAdulteryIsNamed",
-    "TabFieldDisplayOrder": 24,
-    "FieldShowCondition": "D8ReasonForDivorceAdulteryWishToName=\"hiddenfield\""
+    "CaseFieldID": "D8caseReference",
+    "TabFieldDisplayOrder": 1,
+    "TabShowCondition": "D8ReasonForDivorce=\"adultery\" AND D8ReasonForDivorceAdulteryIsNamed=\"Y*\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "createdDate",
+    "TabFieldDisplayOrder": 2
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "D8ReasonForDivorceAdultery3rdPartyFName",
+    "TabFieldDisplayOrder": 3
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "D8ReasonForDivorceAdultery3rdPartyLName",
+    "TabFieldDisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespEmailAddress",
+    "TabFieldDisplayOrder": 5
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespPhoneNumber",
+    "TabFieldDisplayOrder": 6
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "D8DerivedReasonForDivorceAdultery3rdAddr",
+    "TabFieldDisplayOrder": 7
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespConsentToEmail",
+    "TabFieldDisplayOrder": 8
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "labelCoRespAnswers",
+    "TabFieldDisplayOrder": 9
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespConfirmReadPetition",
+    "TabFieldDisplayOrder": 10
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "D8ReasonForDivorce",
+    "TabFieldDisplayOrder": 11
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "solicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespDefendsDivorce",
+    "TabFieldDisplayOrder": 12
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespAdmitAdultery",
+    "TabFieldDisplayOrder": 13
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespAgreeToCosts",
+    "TabFieldDisplayOrder": 14
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespCostsReason",
+    "TabFieldDisplayOrder": 15
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespStatementOfTruth",
+    "TabFieldDisplayOrder": 16
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespContactMethodIsDigital",
+    "TabFieldDisplayOrder": 17
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "ReceivedAosFromCoResp",
+    "TabFieldDisplayOrder": 18
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "ReceivedAosFromCoRespDate",
+    "TabFieldDisplayOrder": 19
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "CoRespLetterHolderId",
+    "TabFieldDisplayOrder": 20
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "DueDateCoResp",
+    "TabFieldDisplayOrder": 21
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "ReceivedAnswerFromCoResp",
+    "TabFieldDisplayOrder": 22
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "SolicitorCoRespondent",
+    "TabLabel": "Co-Respondent",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "ReceivedAnswerFromCoRespDate",
+    "TabFieldDisplayOrder": 23
   },
   {
     "LiveFrom": "22/02/2019",


### PR DESCRIPTION
OR operator does not work for tab show condition . Only AND is handled.
So, created a new set of fields in another tab with the same name and diff show condition.

D8ReasonForDivorceAdulteryWishToName & D8ReasonForDivorceAdulteryIsNamed fields are to be shown only in ReasonForDivorce tab.

Replacement for PR:  https://github.com/hmcts/div-ccd-definitions/pull/14
[ccd-config-base.xlsx](https://github.com/hmcts/div-ccd-definitions/files/3199405/ccd-config-base.xlsx)

**Tested with** 

PFE journey

https://www-ccd.aat.platform.hmcts.net/case/DIVORCE/DIVORCE/1553524994931028#coRespondent

Solicitor Adultery journey

https://www-ccd.aat.platform.hmcts.net/case/DIVORCE/DIVORCE/1558089647667325#facts

https://www-ccd.aat.platform.hmcts.net/case/DIVORCE/DIVORCE/1558015802390213#SolicitorCoRespondent