### PR TITLE
Case mistake on tab id 

### DIFF
--- a/definitions/divorce/json/CaseTypeTab.json
+++ b/definitions/divorce/json/CaseTypeTab.json
@@ -2197,7 +2197,7 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "Channel": "CaseWorker",
-    "TabID": "solicitorCoRespondent",
+    "TabID": "SolicitorCoRespondent",
     "TabLabel": "Co-Respondent",
     "TabDisplayOrder": 3,
     "CaseFieldID": "CoRespDefendsDivorce",


### PR DESCRIPTION
Duplicate coresp tab because of smaller case on case tab id for one field