### PR TITLE
DIV-4838 - removed unwanted RespAgreeToCostsEnum options

### DIFF
--- a/definitions/divorce/json/FixedLists.json
+++ b/definitions/divorce/json/FixedLists.json
@@ -546,30 +546,6 @@
     "ListElement": "No"
   },
   {
-    "LiveFrom": "31/08/2018",
-    "ID": "RespAgreeToCostsEnum",
-    "ListElementCode": "DifferentAmount",
-    "ListElement": "Different amount"
-  },
-  {
-    "LiveFrom": "31/08/2018",
-    "ID": "RespAgreeToCostsEnum",
-    "ListElementCode": "yes",
-    "ListElement": "Yes - Remove"
-  },
-  {
-    "LiveFrom": "31/08/2018",
-    "ID": "RespAgreeToCostsEnum",
-    "ListElementCode": "no",
-    "ListElement": "No - Remove"
-  },
-  {
-    "LiveFrom": "31/08/2018",
-    "ID": "RespAgreeToCostsEnum",
-    "ListElementCode": "differentAmount",
-    "ListElement": "Different amount - Remove"
-  },
-  {
     "LiveFrom": "05/09/2018",
     "ID": "DivorceCostsOptionDNEnum",
     "ListElementCode": "originalAmount",


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines




### JIRA link (if applicable) ###
DIV-4838


### Change description ###

removed unwanted RespAgreeToCostsEnum options

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
