### PR TITLE
DIV-5035 Add missing fixed-list value for DivorceCostsOptionDN

### DIFF
--- a/definitions/divorce/json/FixedLists.json
+++ b/definitions/divorce/json/FixedLists.json
@@ -564,6 +564,12 @@
     "ListElement": "I still want to claim my costs and will let the court decide how much"
   },
   {
+    "LiveFrom": "05/09/2018",
+    "ID": "DivorceCostsOptionDNEnum",
+    "ListElementCode": "differentAmount",
+    "ListElement": "I want to claim a different amount of costs"
+  },
+  {
     "LiveFrom": "19/10/2018",
     "ID": "permittedDecreeNisiEnum",
     "ListElementCode": 0,


### PR DESCRIPTION
A line was missing from the config which is added here.

https://tools.hmcts.net/jira/browse/DIV-5035