### PR TITLE
DIV-5068 Amend sols journey to use D8ReasonForDivorceAdulteryWishToName

### DIFF
--- a/definitions/divorce/json/CaseEventToFields.json
+++ b/definitions/divorce/json/CaseEventToFields.json
@@ -1472,7 +1472,7 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseEventID": "solicitorCreate",
-    "CaseFieldID": "D8ReasonForDivorceAdulteryIsNamed",
+    "CaseFieldID": "D8ReasonForDivorceAdulteryWishToName",
     "PageFieldDisplayOrder": 4,
     "DisplayContext": "MANDATORY",
     "PageID": "SolSOCCoRespondent",
@@ -1490,7 +1490,7 @@
     "PageID": "SolSOCCoRespondent",
     "PageLabel": "Statement of case - adultery",
     "PageDisplayOrder": 9,
-    "FieldShowCondition": "D8ReasonForDivorceAdulteryIsNamed=\"Yes\"",
+    "FieldShowCondition": "D8ReasonForDivorceAdulteryWishToName=\"Yes\"",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -1503,7 +1503,7 @@
     "PageID": "SolSOCCoRespondent",
     "PageLabel": "Statement of case - adultery",
     "PageDisplayOrder": 9,
-    "FieldShowCondition": "D8ReasonForDivorceAdulteryIsNamed=\"Yes\"",
+    "FieldShowCondition": "D8ReasonForDivorceAdulteryWishToName=\"Yes\"",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -1516,7 +1516,7 @@
     "PageID": "SolSOCCoRespondent",
     "PageLabel": "Statement of case - adultery",
     "PageDisplayOrder": 9,
-    "FieldShowCondition": "D8ReasonForDivorceAdulteryIsNamed=\"Yes\"",
+    "FieldShowCondition": "D8ReasonForDivorceAdulteryWishToName=\"Yes\"",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -1906,7 +1906,7 @@
     "PageID": "SolApplyToClaimCosts",
     "PageLabel": "Claim for costs",
     "PageDisplayOrder": 17,
-    "FieldShowCondition": "D8ReasonForDivorceAdulteryIsNamed=\"Yes\"",
+    "FieldShowCondition": "D8ReasonForDivorceAdulteryWishToName=\"Yes\"",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -3292,7 +3292,7 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseEventID": "solicitorUpdate",
-    "CaseFieldID": "D8ReasonForDivorceAdulteryIsNamed",
+    "CaseFieldID": "D8ReasonForDivorceAdulteryWishToName",
     "PageFieldDisplayOrder": 4,
     "DisplayContext": "MANDATORY",
     "PageID": "SolSOCCoRespondentUpdate",
@@ -3310,7 +3310,7 @@
     "PageID": "SolSOCCoRespondentUpdate",
     "PageLabel": "Statement of case - adultery",
     "PageDisplayOrder": 9,
-    "FieldShowCondition": "D8ReasonForDivorceAdulteryIsNamed=\"Yes\"",
+    "FieldShowCondition": "D8ReasonForDivorceAdulteryWishToName=\"Yes\"",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -3323,7 +3323,7 @@
     "PageID": "SolSOCCoRespondentUpdate",
     "PageLabel": "Statement of case - adultery",
     "PageDisplayOrder": 9,
-    "FieldShowCondition": "D8ReasonForDivorceAdulteryIsNamed=\"Yes\"",
+    "FieldShowCondition": "D8ReasonForDivorceAdulteryWishToName=\"Yes\"",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -3336,7 +3336,7 @@
     "PageID": "SolSOCCoRespondentUpdate",
     "PageLabel": "Statement of case - adultery",
     "PageDisplayOrder": 9,
-    "FieldShowCondition": "D8ReasonForDivorceAdulteryIsNamed=\"Yes\"",
+    "FieldShowCondition": "D8ReasonForDivorceAdulteryWishToName=\"Yes\"",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -3726,7 +3726,7 @@
     "PageID": "SolApplyToClaimCostsUpdate",
     "PageLabel": "Claim for costs",
     "PageDisplayOrder": 17,
-    "FieldShowCondition": "D8ReasonForDivorceAdulteryIsNamed=\"Yes\"",
+    "FieldShowCondition": "D8ReasonForDivorceAdulteryWishToName=\"Yes\"",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -4344,7 +4344,7 @@
     "CaseFieldID": "D8DerivedReasonForDivorceAdultery3rdAddr",
     "DisplayContext": "OPTIONAL",
     "PageID": 1,
-    "FieldShowCondition": "D8ReasonForDivorceAdulteryIsNamed=\"Yes\""
+    "FieldShowCondition": "D8ReasonForDivorceAdulteryWishToName=\"Yes\""
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/divorce/json/CaseType.json
+++ b/definitions/divorce/json/CaseType.json
@@ -2,7 +2,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "DIVORCE",
-    "Name": "Divorce case - v113.29",
+    "Name": "Divorce case - v113.30",
     "Description": "Handling of the dissolution of marriage",
     "JurisdictionID": "DIVORCE",
     "PrintableDocumentsUrl": "${CCD_DEF_CCD_URL}/callback/jurisdictions/DIVORCE/case-types/DIVORCE/documents",

--- a/definitions/divorce/json/CaseTypeTab.json
+++ b/definitions/divorce/json/CaseTypeTab.json
@@ -2151,7 +2151,7 @@
     "TabDisplayOrder": 3,
     "CaseFieldID": "D8caseReference",
     "TabFieldDisplayOrder": 1,
-    "TabShowCondition": "PetitionerSolicitorEmail=\"*\" AND D8ReasonForDivorceAdulteryWishToName=\"Y*\""
+    "TabShowCondition": "PetitionerSolicitorEmail=\"*\" AND D8ReasonForDivorceAdulteryIsNamed=\"Y*\""
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/divorce/json/CaseTypeTab.json
+++ b/definitions/divorce/json/CaseTypeTab.json
@@ -2151,7 +2151,7 @@
     "TabDisplayOrder": 3,
     "CaseFieldID": "D8caseReference",
     "TabFieldDisplayOrder": 1,
-    "TabShowCondition": "PetitionerSolicitorEmail=\"*\" AND D8ReasonForDivorceAdulteryIsNamed=\"Y*\""
+    "TabShowCondition": "PetitionerSolicitorEmail=\"*\" AND D8ReasonForDivorceAdulteryWishToName=\"Y*\""
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
Legacy and new config using two fields for same purpose - this removes using the field `D8ReasonForDivorceAdulteryIsNamed` from events but keeps it config for legacy compatibility.

We now use `D8ReasonForDivorceAdulteryWishToName` for all events involving adultery.

https://tools.hmcts.net/jira/browse/DIV-5068