### PR TITLE
Div 5099 personal service

### DIFF
--- a/definitions/divorce/json/CaseEventToFields.json
+++ b/definitions/divorce/json/CaseEventToFields.json
@@ -1098,18 +1098,6 @@
     "ShowSummaryChangeOption": "Yes"
   },
   {
-    "LiveFrom": "02/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "solicitorCreate",
-    "CaseFieldID": "PetitionerSolicitorToEffectService",
-    "PageFieldDisplayOrder": 7,
-    "DisplayContext": "MANDATORY",
-    "PageID": "SolAboutTheRespondent",
-    "PageLabel": "About the respondent",
-    "PageDisplayOrder": 3,
-    "ShowSummaryChangeOption": "Yes"
-  },
-  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseEventID": "solicitorCreate",
@@ -2925,18 +2913,6 @@
     "CaseFieldID": "D8DerivedRespondentHomeAddress",
     "PageFieldDisplayOrder": 6,
     "DisplayContext": "OPTIONAL",
-    "PageID": "SolAboutTheRespondentUpdate",
-    "PageLabel": "About the respondent",
-    "PageDisplayOrder": 3,
-    "ShowSummaryChangeOption": "Yes"
-  },
-  {
-    "LiveFrom": "02/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "solicitorUpdate",
-    "CaseFieldID": "PetitionerSolicitorToEffectService",
-    "PageFieldDisplayOrder": 7,
-    "DisplayContext": "MANDATORY",
     "PageID": "SolAboutTheRespondentUpdate",
     "PageLabel": "About the respondent",
     "PageDisplayOrder": 3,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DIV-5099


### Change description ###
PetitionerSolicitorToEffectService removed from solicitorCreate and solicitorUpdate events.
Request to remove PetitionerSolicitorToEffectService from SolicitorCreate and SolicitorUpdate events. 

This is causing issues because personal service is not yet supported. 

This feature will later be added in as part of the Personal Service journey - DIV-4912

AC:

During solicitorCreate and solicitorUpdate, solicitor is not asked if they wish to effect personal service to the respondent on the respondent details page
