### PR TITLE
Add Ability for RDC caseworkers to see AwaitingReissue cases and move…

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseEvent.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent.json
@@ -492,6 +492,13 @@
   {
     "LiveFrom": "09/11/2018",
     "CaseTypeID": "DIVORCE",
+    "CaseEventID": "issuedFromReissue",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "09/11/2018",
+    "CaseTypeID": "DIVORCE",
     "CaseEventID": "issueAosFromReissue",
     "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "CRU"

--- a/definitions/divorce/json/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState.json
@@ -241,6 +241,13 @@
     "LiveFrom": "09/11/2018",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingReissue",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "RU"
+  },
+  {
+    "LiveFrom": "09/11/2018",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AwaitingReissue",
     "UserRole": "citizen",
     "CRUD": "RU"
   },

--- a/definitions/divorce/json/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent.json
@@ -723,6 +723,17 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
+    "ID": "issuedFromReissue",
+    "Name": "Reissue",
+    "Description": "Reissue petition",
+    "DisplayOrder": 3,
+    "PreConditionState(s)": "AwaitingReissue",
+    "PostConditionState": "Issued",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
     "ID": "startAosFromReissue",
     "Name": "AOS started",
     "Description": "AOS started",

--- a/definitions/divorce/json/CaseType.json
+++ b/definitions/divorce/json/CaseType.json
@@ -2,7 +2,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "DIVORCE",
-    "Name": "Divorce case - v114.22",
+    "Name": "Divorce case - v114.23",
     "Description": "Handling of the dissolution of marriage",
     "JurisdictionID": "DIVORCE",
     "PrintableDocumentsUrl": "${CCD_DEF_CCD_URL}/callback/jurisdictions/DIVORCE/case-types/DIVORCE/documents",


### PR DESCRIPTION
### JIRA link (if applicable) ###

Incident Number: INC0482505

### Change description ###

The RDC caseworker has a case in AwaitingReissue state they are unable to view and progress.
Since its a non-online journey, this PR lets them move it from that state to Issued state only, and nothing else.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
