### PR TITLE
Add Aos States and DN states to be viewable by Solicitor users

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState.json
@@ -1269,9 +1269,37 @@
   {
     "LiveFrom": "31/05/2019",
     "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AosStarted",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "31/05/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AosSubmittedAwaitingAnswer",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "31/05/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AosCompleted",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "31/05/2019",
+    "CaseTypeID": "DIVORCE",
     "CaseStateID": "AosAwaitingSol",
     "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "25/06/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AwaitingPronouncement",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
   },
   {
     "LiveFrom": "25/06/2019",


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DIV-5556 - Solicitor can't view case](https://tools.hmcts.net/jira/browse/DIV-5556)

### Change description ###

This adds READ permissions for Petitioner Solicitor users to view cases that are currently in the AOS flow
(AosAwaiting -> AosStarted -> AosComplete (or AosSubmittedAwaitingAnswer), that has been started by the Respondent.
Solicitor already had READ permission for AwaitingDecreeNisi and DNPronounced state, but was missing READ for AwaitingPronouncement (the state between these two).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
