### PR TITLE
add missing changes from RDM-5755

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,4 @@ To run divorce test on CCD PR environment you need to replace `core_case_data.ap
 
 When we want to release config changes to production:
 
-1) Generate all excel files using `yarn generate-excel-all` 
-2) Upload the excel file for the AAT env and QA the changes
-3) Create a new release in https://github.com/hmcts/div-ccd-definitions/releases/new
-4) Upload all the generate Excel files to the release and add give it the same version number from (3)
-5) Raise a RDM ticket (e.g. RDM-5372) and add link to the release created in step (7)
-6) Ask tester to sign off the RDM if changes pass and assign the RDM ticket to someone in the RDM team
+[Release Config Changes to Prod](https://tools.hmcts.net/confluence/display/DIV/Release+Config+Changes+to+Production)

--- a/definitions/divorce/json/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent.json
@@ -2182,7 +2182,7 @@
     "DisplayOrder": 23,
     "PreConditionState(s)": "AwaitingDecreeAbsolute",
     "PostConditionState": "DARequested",
-    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
+    "RetriesTimeoutURLSubmitEvent": "120,120",
     "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/da-requested-by-applicant",
     "SecurityClassification": "Public"
   },

--- a/definitions/divorce/json/CaseType.json
+++ b/definitions/divorce/json/CaseType.json
@@ -2,7 +2,7 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "DIVORCE",
-    "Name": "Divorce case - v114.30",
+    "Name": "Divorce case - v114.31",
     "Description": "Handling of the dissolution of marriage",
     "JurisdictionID": "DIVORCE",
     "PrintableDocumentsUrl": "${CCD_DEF_CCD_URL}/callback/jurisdictions/DIVORCE/case-types/DIVORCE/documents",


### PR DESCRIPTION
This is to add missing changes while the **master** was being synced with the **prod**. The original PR can be referenced here https://github.com/hmcts/div-ccd-definitions/pull/255

Main change:
- corrected the type of callback for the event `DARequested`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
