### PR TITLE
BSP-115: added bulkScanCaseReference and events needed for BSP 2.1

### DIFF
--- a/charts/div-ccd-definitions/Chart.yaml
+++ b/charts/div-ccd-definitions/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 description: Divorce - CCD Definitions
 name: div-ccd-definitions
 version: 1.0.0

--- a/definitions/divorce/json/AuthorisationCaseEvent.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent.json
@@ -6309,13 +6309,6 @@
   {
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
-    "CaseEventID": "updateCase",
-    "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "CRU"
-  },
-  {
-    "LiveFrom": "23/05/2019",
-    "CaseTypeID": "DIVORCE",
     "CaseEventID": "createCase",
     "UserRole": "caseworker-divorce-bulkscan",
     "CRUD": "CRU"
@@ -6323,7 +6316,7 @@
   {
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
-    "CaseEventID": "updateCase",
+    "CaseEventID": "attachScannedDocsWithOcr",
     "UserRole": "caseworker-divorce-bulkscan",
     "CRUD": "CRU"
   },
@@ -6337,7 +6330,7 @@
   {
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
-    "CaseEventID": "updateCase",
+    "CaseEventID": "attachScannedDocsWithOcr",
     "UserRole": "caseworker-divorce-courtadmin",
     "CRUD": "R"
   },
@@ -6351,7 +6344,7 @@
   {
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
-    "CaseEventID": "updateCase",
+    "CaseEventID": "attachScannedDocsWithOcr",
     "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "R"
   }

--- a/definitions/divorce/json/AuthorisationCaseEvent.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent.json
@@ -6303,14 +6303,28 @@
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
     "CaseEventID": "bulkScanCaseCreate",
-    "UserRole": "caseworker-divorce-courtadmin",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "CRU"
   },
   {
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
     "CaseEventID": "bulkScanCaseUpdate",
-    "UserRole": "caseworker-divorce-courtadmin",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "23/05/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "bulkScanCaseCreate",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "23/05/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "bulkScanCaseUpdate",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseEvent.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent.json
@@ -6302,29 +6302,57 @@
   {
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
-    "CaseEventID": "bulkScanCaseCreate",
-    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CaseEventID": "createCase",
+    "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "CRU"
   },
   {
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
-    "CaseEventID": "bulkScanCaseUpdate",
-    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CaseEventID": "updateCase",
+    "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "CRU"
   },
   {
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
-    "CaseEventID": "bulkScanCaseCreate",
+    "CaseEventID": "createCase",
+    "UserRole": "caseworker-divorce-bulkscan",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "23/05/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "updateCase",
+    "UserRole": "caseworker-divorce-bulkscan",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "23/05/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "createCase",
     "UserRole": "caseworker-divorce-courtadmin",
     "CRUD": "R"
   },
   {
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
-    "CaseEventID": "bulkScanCaseUpdate",
+    "CaseEventID": "updateCase",
     "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "23/05/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "createCase",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "23/05/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "updateCase",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseEvent.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent.json
@@ -6298,5 +6298,19 @@
     "CaseEventID": "amendPetitionForRefusalRejection",
     "UserRole": "caseworker-divorce-courtadmin-la",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "23/05/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "bulkScanCaseCreate",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "23/05/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "bulkScanCaseUpdate",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "CRU"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseField.json
+++ b/definitions/divorce/json/AuthorisationCaseField.json
@@ -14670,5 +14670,12 @@
     "CaseFieldID": "ClarificationDigital",
     "UserRole": "caseworker-divorce-courtadmin",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "bulkScanCaseReference",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "CRU"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseField.json
+++ b/definitions/divorce/json/AuthorisationCaseField.json
@@ -14675,7 +14675,14 @@
     "LiveFrom": "01/01/2019",
     "CaseTypeID": "DIVORCE",
     "CaseFieldID": "bulkScanCaseReference",
-    "UserRole": "caseworker-divorce-courtadmin",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "CRU"
-  }
+  },
+  {
+    "LiveFrom": "01/01/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "bulkScanCaseReference",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
 ]

--- a/definitions/divorce/json/AuthorisationCaseField.json
+++ b/definitions/divorce/json/AuthorisationCaseField.json
@@ -14675,8 +14675,22 @@
     "LiveFrom": "01/01/2019",
     "CaseTypeID": "DIVORCE",
     "CaseFieldID": "bulkScanCaseReference",
-    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "bulkScanCaseReference",
+    "UserRole": "caseworker-divorce-bulkscan",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2019",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "bulkScanCaseReference",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2019",

--- a/definitions/divorce/json/AuthorisationCaseField.json
+++ b/definitions/divorce/json/AuthorisationCaseField.json
@@ -14684,5 +14684,5 @@
     "CaseFieldID": "bulkScanCaseReference",
     "UserRole": "caseworker-divorce-courtadmin",
     "CRUD": "R"
-  },
+  }
 ]

--- a/definitions/divorce/json/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState.json
@@ -417,70 +417,70 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingPayment",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingHWFDecision",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingDocuments",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "Submitted",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "Issued",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "Rejected",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "PendingRejection",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "SOTAgreementPayAndSubmitRequired",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "solicitorAwaitingPaymentConfirmation",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AosAwaiting",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -494,7 +494,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AosStarted",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -508,7 +508,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AosSubmittedAwaitingAnswer",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -522,7 +522,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingDecreeNisi",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -536,7 +536,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AosOverdue",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -550,14 +550,14 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingReissue",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingLegalAdvisorReferral",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -571,7 +571,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingConsideration",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -585,7 +585,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AmendPetition",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -606,7 +606,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingClarification",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -627,7 +627,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "DefendedDivorce",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -648,7 +648,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingPronouncement",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -662,7 +662,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingDecreeAbsolute",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -683,14 +683,14 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "DNPronounced",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "DivorceGranted",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -711,14 +711,14 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "Withdrawn",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AosCompleted",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -1005,7 +1005,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "DNisRefused",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2019",
@@ -1033,7 +1033,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AosAwaitingSol",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -1551,7 +1551,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "DARequested",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "25/06/2019",
@@ -1607,7 +1607,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "DAOverdue",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "20/08/2019",
@@ -1649,7 +1649,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "DNDrafted",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "25/06/2019",
@@ -1691,7 +1691,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AosDrafted",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "12/08/2019",
@@ -1747,7 +1747,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AosPreSubmit",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "12/08/2019",
@@ -1845,7 +1845,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "RemovedFromBulkCaseList",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "25/06/2019",
@@ -1887,7 +1887,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingService",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -1964,7 +1964,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "ClarificationSubmitted",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "25/06/2019",
@@ -2027,7 +2027,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingAdminClarification",
     "UserRole": "caseworker-divorce-systemupdate",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "25/06/2019",

--- a/definitions/divorce/json/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent.json
@@ -2734,5 +2734,27 @@
     "PreConditionState(s)": "DNisRefused",
     "PostConditionState": "AmendPetition",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2019",
+    "CaseTypeID": "DIVORCE",
+    "ID": "bulkScanCaseCreate",
+    "Name": "Bulk Scanning - Case Create",
+    "Description": "Create a case from scanned documents",
+    "DisplayOrder": 1,
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2019",
+    "CaseTypeID": "DIVORCE",
+    "ID": "bulkScanCaseUpdate",
+    "Name": "Bulk Scanning - Case Update",
+    "Description": "Update a case adding additional data from scanned documents to an existing case",
+    "DisplayOrder": 1,
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/divorce/json/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent.json
@@ -2749,7 +2749,7 @@
   {
     "LiveFrom": "01/01/2019",
     "CaseTypeID": "DIVORCE",
-    "ID": "updateCase",
+    "ID": "attachScannedDocsWithOcr",
     "Name": "Bulk Scanning - Case Update",
     "Description": "Update a case adding additional data from scanned documents to an existing case",
     "DisplayOrder": 21,

--- a/definitions/divorce/json/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent.json
@@ -2738,7 +2738,7 @@
   {
     "LiveFrom": "01/01/2019",
     "CaseTypeID": "DIVORCE",
-    "ID": "bulkScanCaseCreate",
+    "ID": "createCase",
     "Name": "Bulk Scanning - Case Create",
     "Description": "Create a case from scanned documents",
     "DisplayOrder": 20,
@@ -2749,7 +2749,7 @@
   {
     "LiveFrom": "01/01/2019",
     "CaseTypeID": "DIVORCE",
-    "ID": "bulkScanCaseUpdate",
+    "ID": "updateCase",
     "Name": "Bulk Scanning - Case Update",
     "Description": "Update a case adding additional data from scanned documents to an existing case",
     "DisplayOrder": 21,

--- a/definitions/divorce/json/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent.json
@@ -2741,7 +2741,7 @@
     "ID": "bulkScanCaseCreate",
     "Name": "Bulk Scanning - Case Create",
     "Description": "Create a case from scanned documents",
-    "DisplayOrder": 1,
+    "DisplayOrder": 20,
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public"
@@ -2752,7 +2752,7 @@
     "ID": "bulkScanCaseUpdate",
     "Name": "Bulk Scanning - Case Update",
     "Description": "Update a case adding additional data from scanned documents to an existing case",
-    "DisplayOrder": 1,
+    "DisplayOrder": 21,
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public"

--- a/definitions/divorce/json/CaseField.json
+++ b/definitions/divorce/json/CaseField.json
@@ -3769,5 +3769,13 @@
     "Label": "Is the DN clarification sent digitally (online) or not?",
     "FieldType": "YesOrNo",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE",
+    "ID": "bulkScanCaseReference",
+    "Label": "Exception Record Reference",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
   }
 ]


### PR DESCRIPTION
Updated Divorce CCD spreadsheet according to RBS documentation for BSP Phase 2 and 2.1

https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1064666568#TechnicalprerequisitesandinformationforServiceon-boardingwithPhase2Bulkscanningforcasecreation.-2.1CCDConfiguration