### PR TITLE
RPET-58: Remove the deprecated enableDockerBuild() configuration

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -33,7 +33,6 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withPipeline("nodejs", product, component) {
 
   if (env.CHANGE_TITLE && !env.CHANGE_TITLE.startsWith('[NO-CCD]')) {
-    enableDockerBuild()
     installCharts()
   }
 


### PR DESCRIPTION
# Description

`enableDockerBuild() is deprecated, a Dockerfile has been mandatory since 17/12/2019, please remove this option from your Jenkinsfile This configuration will stop working by 18/02/2020 00:00 AM ( in 10 days )`

Fixes https://tools.hmcts.net/jira/browse/RPET-58

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
