### PR TITLE
DIV-6420 (sub-task DIV-6198) field authorisations modified to enable solicitors create new amended cases

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-nonprod.json
@@ -103,5 +103,19 @@
     "CaseFieldID": "LabelAmendPetitionForRefusalSolPara-6",
     "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "06/07/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "D8Cohort",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "06/07/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "PreviousIssueDate",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "CRU"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-prod.json
+++ b/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-prod.json
@@ -1,0 +1,9 @@
+[
+  {
+    "LiveFrom": "31/08/2018",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "PreviousIssueDate",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  }
+]

--- a/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -7098,13 +7098,6 @@
     "CRUD": "CRU"
   },
   {
-    "LiveFrom": "31/08/2018",
-    "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "PreviousIssueDate",
-    "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "R"
-  },
-  {
     "LiveFrom": "29/03/2019",
     "CaseTypeID": "DIVORCE",
     "CaseFieldID": "CaseHistory",

--- a/test/unit/definitions/divorce/AuthorisationCaseField.test.js
+++ b/test/unit/definitions/divorce/AuthorisationCaseField.test.js
@@ -16,11 +16,10 @@ function mergeJsonFilesFor(whatFolder, nonProdStartsWith) {
   const authCaseFieldNonProd = [];
 
   files.forEach(filename => {
-    const filenameRegEx = new RegExp(`${nonProdStartsWith}.*.json`, 'i');
+    const filenameRegEx = new RegExp(`${nonProdStartsWith}.*nonprod.json`, 'i');
     if (filename.match(filenameRegEx)) {
-       const nonProdFile = Object
-          .assign(load(`${whatFolder}/${filename}`), {});
-       authCaseFieldNonProd.push(...nonProdFile);
+      const nonProdFile = Object.assign(load(`${whatFolder}/${filename}`), {});
+      authCaseFieldNonProd.push(...nonProdFile);
     }
   });
 
@@ -28,13 +27,13 @@ function mergeJsonFilesFor(whatFolder, nonProdStartsWith) {
 }
 
 describe('AuthorisationCaseField', () => {
-  if (fs.existsSync('definitions/divorce/json/AuthorisationCaseField/')){
-     it('should contain a unique case field ID, case type ID and role (no duplicates) for non prod files', () => {
-        const jsonConfigFiles = mergeJsonFilesFor('definitions/divorce/json/AuthorisationCaseField/', 'AuthorisationCaseField-');
-        const uniqResult = uniqWith(jsonConfigFiles, isDuplicated);
+  if (fs.existsSync('definitions/divorce/json/AuthorisationCaseField/')) {
+    it('should contain a unique case field ID, case type ID and role (no duplicates) for non prod files', () => {
+      const jsonConfigFiles = mergeJsonFilesFor('definitions/divorce/json/AuthorisationCaseField/', 'AuthorisationCaseField-');
+      const uniqResult = uniqWith(jsonConfigFiles, isDuplicated);
 
-        expect(uniqResult).to.eql(jsonConfigFiles);
-     });
+      expect(uniqResult).to.eql(jsonConfigFiles);
+    });
   }
 
   it('should contain a unique case field ID, case type ID and role (no duplicates) for prod file', () => {

--- a/test/unit/definitions/divorce/AuthorisationCaseState.test.js
+++ b/test/unit/definitions/divorce/AuthorisationCaseState.test.js
@@ -5,30 +5,30 @@ const load = require;
 const authCaseStateCommon = Object.assign(require('definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState'), {});
 
 function isDuplicated(field1, field2) {
-    return field1.CaseTypeID === field2.CaseTypeID
+  return field1.CaseTypeID === field2.CaseTypeID
         && field1.CaseStateID === field2.CaseStateID
         && field1.UserRole === field2.UserRole;
 }
 
 function mergeJsonFilesFor(whatEnvs) {
-    const authCaseForSpecificEnvs = Object
-        .assign(load(`definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-${whatEnvs}`), {});
+  const authCaseForSpecificEnvs = Object
+    .assign(load(`definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-${whatEnvs}`), {});
 
-    return [...authCaseStateCommon, ...authCaseForSpecificEnvs];
+  return [...authCaseStateCommon, ...authCaseForSpecificEnvs];
 }
 
 describe('AuthorisationCaseState', () => {
-    it('should contain a unique case state, case type ID and role (no duplicates) for nonprod files', () => {
-        const nonProd = mergeJsonFilesFor('nonprod');
-        const uniqResult = uniqWith(nonProd, isDuplicated);
+  it('should contain a unique case state, case type ID and role (no duplicates) for nonprod files', () => {
+    const nonProd = mergeJsonFilesFor('nonprod');
+    const uniqResult = uniqWith(nonProd, isDuplicated);
 
-        expect(uniqResult).to.eql(nonProd);
-    });
+    expect(uniqResult).to.eql(nonProd);
+  });
 
-    it('should contain a unique case state ID, case type ID and role (no duplicates) for prod file', () => {
-        const prodOnly = mergeJsonFilesFor('prod');
-        const uniqResult = uniqWith(prodOnly, isDuplicated);
+  it('should contain a unique case state ID, case type ID and role (no duplicates) for prod file', () => {
+    const prodOnly = mergeJsonFilesFor('prod');
+    const uniqResult = uniqWith(prodOnly, isDuplicated);
 
-        expect(uniqResult).to.eql(prodOnly);
-    });
+    expect(uniqResult).to.eql(prodOnly);
+  });
 });

--- a/test/unit/definitions/divorce/AuthorisationCaseType.test.js
+++ b/test/unit/definitions/divorce/AuthorisationCaseType.test.js
@@ -17,9 +17,9 @@ function mergeJsonFilesFor(whatFolder, nonProdStartsWith) {
   files.forEach(filename => {
     const filenameRegEx = new RegExp(`${nonProdStartsWith}.*.json`, 'i');
     if (filename.match(filenameRegEx)) {
-       const nonProdFile = Object
-          .assign(load(`${whatFolder}/${filename}`), {});
-       authCaseTypeNonProd.push(...nonProdFile);
+      const nonProdFile = Object
+        .assign(load(`${whatFolder}/${filename}`), {});
+      authCaseTypeNonProd.push(...nonProdFile);
     }
   });
 
@@ -27,13 +27,13 @@ function mergeJsonFilesFor(whatFolder, nonProdStartsWith) {
 }
 
 describe('AuthorisationCaseType', () => {
-  if (fs.existsSync('definitions/divorce/json/AuthorisationCaseType/')){
-     it('should contain a unique case type ID and role (no duplicates) for non prod files', () => {
-        const jsonConfigFiles = mergeJsonFilesFor('definitions/divorce/json/AuthorisationCaseType/', 'AuthorisationCaseType-');
-        const uniqResult = uniqWith(jsonConfigFiles, isDuplicated);
+  if (fs.existsSync('definitions/divorce/json/AuthorisationCaseType/')) {
+    it('should contain a unique case type ID and role (no duplicates) for non prod files', () => {
+      const jsonConfigFiles = mergeJsonFilesFor('definitions/divorce/json/AuthorisationCaseType/', 'AuthorisationCaseType-');
+      const uniqResult = uniqWith(jsonConfigFiles, isDuplicated);
 
-        expect(uniqResult).to.eql(jsonConfigFiles);
-     });
+      expect(uniqResult).to.eql(jsonConfigFiles);
+    });
   }
 
   it('should contain a unique case type ID and role (no duplicates) for prod file', () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6198

### Change description ###

Currently, when trying to create a new case using a solicitor.
The workflow would fail if the case data contains the following fields:
* D8Cohort
* PreviousIssueDate
This is because in the definition file (i.e. div-ccd-definitions), solicitors do not have the necessary permissions to create a case with those fields.

**Action**
Adjusted authorisations to allow solicitors to create amended case.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
