### PR TITLE
PCQ-493: Corrected spelling in respondent field.

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-pcq-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-pcq-nonprod.json
@@ -58,112 +58,112 @@
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "RespondantPcqId",
+    "CaseFieldID": "RespondentPcqId",
     "UserRole": "citizen",
     "CRUD": "CRU"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "RespondantPcqId",
+    "CaseFieldID": "RespondentPcqId",
     "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "RespondantPcqId",
+    "CaseFieldID": "RespondentPcqId",
     "UserRole": "caseworker-divorce-courtadmin",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "RespondantPcqId",
+    "CaseFieldID": "RespondentPcqId",
     "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "RespondantPcqId",
+    "CaseFieldID": "RespondentPcqId",
     "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "RespondantPcqId",
+    "CaseFieldID": "RespondentPcqId",
     "UserRole": "caseworker-divorce-bulkscan",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "RespondantPcqId",
+    "CaseFieldID": "RespondentPcqId",
     "UserRole": "caseworker-divorce-courtadmin-la",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "RespondantPcqId",
+    "CaseFieldID": "RespondentPcqId",
     "UserRole": "caseworker-divorce-superuser",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "CoRespondantPcqId",
+    "CaseFieldID": "CoRespondentPcqId",
     "UserRole": "citizen",
     "CRUD": "CRU"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "CoRespondantPcqId",
+    "CaseFieldID": "CoRespondentPcqId",
     "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "CoRespondantPcqId",
+    "CaseFieldID": "CoRespondentPcqId",
     "UserRole": "caseworker-divorce-courtadmin",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "CoRespondantPcqId",
+    "CaseFieldID": "CoRespondentPcqId",
     "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "CoRespondantPcqId",
+    "CaseFieldID": "CoRespondentPcqId",
     "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "CoRespondantPcqId",
+    "CaseFieldID": "CoRespondentPcqId",
     "UserRole": "caseworker-divorce-bulkscan",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "CoRespondantPcqId",
+    "CaseFieldID": "CoRespondentPcqId",
     "UserRole": "caseworker-divorce-courtadmin-la",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "CoRespondantPcqId",
+    "CaseFieldID": "CoRespondentPcqId",
     "UserRole": "caseworker-divorce-superuser",
     "CRUD": "R"
   },
@@ -177,14 +177,14 @@
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "RespondantPcqId",
+    "CaseFieldID": "RespondentPcqId",
     "UserRole": "caseworker-divorce-pcqextractor",
     "CRUD": "R"
   },
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "CoRespondantPcqId",
+    "CaseFieldID": "CoRespondentPcqId",
     "UserRole": "caseworker-divorce-pcqextractor",
     "CRUD": "R"
   }

--- a/definitions/divorce/json/CaseField/CaseField-pcq-nonprod.json
+++ b/definitions/divorce/json/CaseField/CaseField-pcq-nonprod.json
@@ -10,7 +10,7 @@
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "ID": "RespondantPcqId",
+    "ID": "RespondentPcqId",
     "Label": "Respondent PCQ ID",
     "FieldType": "Text",
     "SecurityClassification": "Public"
@@ -18,7 +18,7 @@
   {
     "LiveFrom": "15/06/2020",
     "CaseTypeID": "DIVORCE",
-    "ID": "CoRespondantPcqId",
+    "ID": "CoRespondentPcqId",
     "Label": "Co-respondent PCQ ID",
     "FieldType": "Text",
     "SecurityClassification": "Public"

--- a/definitions/divorce/json/CaseTypeTab/CaseTypeTab-pcq-nonprod.json
+++ b/definitions/divorce/json/CaseTypeTab/CaseTypeTab-pcq-nonprod.json
@@ -16,7 +16,7 @@
       "TabID": "coRespondent",
       "TabLabel": "Co-Respondent",
       "TabDisplayOrder": 22,
-      "CaseFieldID": "CoRespondantPcqId",
+      "CaseFieldID": "CoRespondentPcqId",
       "TabFieldDisplayOrder": 33
     },
     {
@@ -26,7 +26,7 @@
         "TabID": "aosDetails",
         "TabLabel": "AOS",
         "TabDisplayOrder": 3,
-        "CaseFieldID": "RespondantPcqId",
+        "CaseFieldID": "RespondentPcqId",
         "TabFieldDisplayOrder": 30
     }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-493


### Change description ###
Update to correct spelling of respondent and co-respondent fields.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
