### PR TITLE
DIV-6198: Previously added event authorisation removed

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-prod.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-prod.json
@@ -47,12 +47,5 @@
     "CaseEventID": "EnterAOSOffline_CoRespondent",
     "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "R"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "amendPetitionForRefusalRejection",
-    "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-solicitorDn-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-solicitorDn-nonprod.json
@@ -1,9 +1,0 @@
-[
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "amendPetitionForRefusalRejection",
-    "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "CRU"
-  }
-]

--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -6175,6 +6175,13 @@
     "CRUD": "R"
   },
   {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "amendPetitionForRefusalRejection",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
     "LiveFrom": "23/05/2019",
     "CaseTypeID": "DIVORCE",
     "CaseEventID": "createCase",


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6198

### Change description ###

I previously added authorisations to allow the solicitor to run the event: amendPetitionForRefusalRejection
Those authorisations are actually not necessary. Putting it back the way it was before.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
