### PR TITLE
DIV-6193: Adding permissions to allow amendPetition event to be triggered from awaitingAmendCase

### DIFF
--- a/definitions/divorce/json/CaseEvent/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent.json
@@ -1314,7 +1314,7 @@
     "Name": "Amend Petition",
     "Description": "Amend Petition",
     "DisplayOrder": 2,
-    "PreConditionState(s)": "AosCompleted",
+    "PreConditionState(s)": "AosCompleted;AwaitingAmendCase",
     "PostConditionState": "AmendPetition",
     "SecurityClassification": "Public"
   },


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6193

### Change description ###

Currently, the 'amendPetition' event can only be called from the state 'AOSCompleted'.
A new pre-state condition has been added so that this event can be triggered from 'AwaitingAmendCase'.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
