### PR TITLE
DIV-6094: When deemed or dispensed approved, display text, not respondent answers document

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-deemed-and-dispensed-nonprod.json
@@ -635,5 +635,75 @@
     "CaseFieldID": "LabelHWFReference",
     "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelContinueBecauseOfDeemedAccepted",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelContinueBecauseOfDeemedAccepted",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelContinueBecauseOfDeemedAccepted",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelContinueBecauseOfDeemedAccepted",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelContinueBecauseOfDeemedAccepted",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelContinueBecauseOfDispensedAccepted",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelContinueBecauseOfDispensedAccepted",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelContinueBecauseOfDispensedAccepted",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelContinueBecauseOfDispensedAccepted",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelContinueBecauseOfDispensedAccepted",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-deemed-and-dispensed-nonprod.json
@@ -222,5 +222,61 @@
     "PageColumnNumber": 1,
     "FieldShowCondition": "ServiceApplicationPayment=\"helpWithFees\"",
     "ShowSummaryChangeOption": "No"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorApplyForDN",
+    "CaseFieldID": "LabelContinueBecauseOfDeemedAccepted",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "READONLY",
+    "PageID": "dnreviewaos",
+    "PageLabel": "Review Acknowledgement of Service",
+    "PageDisplayOrder": 1,
+    "PageColumnNumber": 1,
+    "FieldShowCondition": "ServiceApplicationGranted=\"Yes\" AND ServiceApplicationType=\"deemed\"",
+    "ShowSummaryChangeOption": "No"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorApplyForDN",
+    "CaseFieldID": "LabelContinueBecauseOfDispensedAccepted",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "READONLY",
+    "PageID": "dnreviewaos",
+    "PageLabel": "Review Acknowledgement of Service",
+    "PageDisplayOrder": 1,
+    "PageColumnNumber": 1,
+    "FieldShowCondition": "ServiceApplicationGranted=\"Yes\" AND ServiceApplicationType=\"dispensed\"",
+    "ShowSummaryChangeOption": "No"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorApplyForDN",
+    "CaseFieldID": "ServiceApplicationGranted",
+    "PageFieldDisplayOrder": 3,
+    "DisplayContext": "READONLY",
+    "PageID": "dnreviewaos",
+    "PageLabel": "Review Acknowledgement of Service",
+    "PageDisplayOrder": 1,
+    "PageColumnNumber": 1,
+    "FieldShowCondition": "DNApplyForDecreeNisi=\"NeverShow\"",
+    "ShowSummaryChangeOption": "No"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorApplyForDN",
+    "CaseFieldID": "ServiceApplicationType",
+    "PageFieldDisplayOrder": 4,
+    "DisplayContext": "READONLY",
+    "PageID": "dnreviewaos",
+    "PageLabel": "Review Acknowledgement of Service",
+    "PageDisplayOrder": 1,
+    "PageColumnNumber": 1,
+    "FieldShowCondition": "DNApplyForDecreeNisi=\"NeverShow\"",
+    "ShowSummaryChangeOption": "No"
   }
 ]

--- a/definitions/divorce/json/CaseField/CaseField-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/CaseField/CaseField-deemed-and-dispensed-nonprod.json
@@ -138,5 +138,21 @@
     "Label": "Fee account reference ${D8HelpWithFeesReferenceNumber}",
     "FieldType": "Label",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "LabelContinueBecauseOfDeemedAccepted",
+    "Label": "Because the court accepted the application for 'deemed service', you are able to continue with the divorce without seeing the respondent answers.",
+    "FieldType": "Label",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "25/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "LabelContinueBecauseOfDispensedAccepted",
+    "Label": "Because the court accepted the application to 'dispense with service’, you are able to continue with the divorce without seeing the respondent answers.",
+    "FieldType": "Label",
+    "SecurityClassification": "Public"
   }
 ]


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6094

### Change description ###

At the decree nisi stage the solicitor is usually presented with a page with a link to the respondent's answers.
Where the case has proceeded to decree nisi stage on the basis of deemed or dispensed, then the answers are not available.
Instead some explanatory text should be set (explaining why no answers are available).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
