### PR TITLE
DIV-6479: Disable 'allow petitioner to amend' event for cases with a petitioner solicitor

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-pet-amend-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-pet-amend-nonprod.json
@@ -1,0 +1,44 @@
+[
+  {
+    "LiveFrom": "28/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelCannotAllowPetToAmendForSolicitorCase",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "28/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelCannotAllowPetToAmendForSolicitorCase",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "28/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelCannotAllowPetToAmendForSolicitorCase",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "28/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelCannotAllowPetToAmendForSolicitorCase",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "28/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelCannotAllowPetToAmendForSolicitorCase",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "28/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "LabelCannotAllowPetToAmendForSolicitorCase",
+    "UserRole": "citizen",
+    "CRUD": "R"
+  }
+]

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-pet-amend-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-pet-amend-nonprod.json
@@ -1,0 +1,29 @@
+[
+  {
+    "LiveFrom": "28/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "allowPetitionerToAmend",
+    "CaseFieldID": "LabelCannotAllowPetToAmendForSolicitorCase",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "READONLY",
+    "PageID": "invalidaction",
+    "PageLabel": "Invalid action",
+    "PageDisplayOrder": 1,
+    "PageColumnNumber": 1,
+    "PageShowCondition": "PetitionerSolicitorEmail=\"*\"",
+    "ShowSummaryChangeOption": "No"
+  },
+  {
+    "LiveFrom": "28/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "allowPetitionerToAmend",
+    "CaseFieldID": "PetitionerSolicitorEmail",
+    "PageFieldDisplayOrder": 2,
+    "DisplayContext": "OPTIONAL",
+    "PageID": "invalidaction",
+    "PageDisplayOrder": 1,
+    "PageColumnNumber": 1,
+    "FieldShowCondition": "LabelCannotAllowPetToAmendForSolicitorCase=\"NeverShow\"",
+    "ShowSummaryChangeOption": "No"
+  }
+]

--- a/definitions/divorce/json/CaseField/CaseField-pet-amend-nonprod.json
+++ b/definitions/divorce/json/CaseField/CaseField-pet-amend-nonprod.json
@@ -1,0 +1,10 @@
+[
+  {
+    "LiveFrom": "28/08/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "LabelCannotAllowPetToAmendForSolicitorCase",
+    "Label": "Because the current case has a solicitor representing the petitioner, this event cannot be used to allow the petitioner to amend this case. Instead, the petitioner's solicitor should amend this case themselves using the event: Submit amended application",
+    "FieldType": "Label",
+    "SecurityClassification": "Public"
+  }
+]


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6479

### Change description ###

As a caseworker
If a solicitor gets in touch with the courts saying that want to amend a case,
I should tell them that (based on the state of their case) they have permissions to select 'submit amended case'
However, If I make a mistake I could accidentally use the 'allow petitioner to amend' event.

The caseworker here are told why they cannot submit this event.
If they still try to, they are return with an error.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
