### PR TITLE
DIV-6142: check your answer page for event createGeneralOrder

### DIFF
--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json
@@ -10,7 +10,7 @@
     "PageLabel": "General order",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "No"
+    "ShowSummaryChangeOption": "Yes"
   },
   {
     "LiveFrom": "27/08/2020",
@@ -23,7 +23,7 @@
     "PageLabel": "General order",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "No"
+    "ShowSummaryChangeOption": "Yes"
   },
   {
     "LiveFrom": "27/08/2020",
@@ -36,7 +36,7 @@
     "PageLabel": "General order",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "No"
+    "ShowSummaryChangeOption": "Yes"
   },
   {
     "LiveFrom": "27/08/2020",
@@ -49,7 +49,7 @@
     "PageLabel": "General order",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "No"
+    "ShowSummaryChangeOption": "Yes"
   },
   {
     "LiveFrom": "27/08/2020",
@@ -62,7 +62,7 @@
     "PageLabel": "General order",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "No"
+    "ShowSummaryChangeOption": "Yes"
   },
   {
     "LiveFrom": "27/08/2020",
@@ -75,7 +75,7 @@
     "PageLabel": "General order",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "No"
+    "ShowSummaryChangeOption": "Yes"
   },
   {
     "LiveFrom": "03/09/2020",
@@ -90,6 +90,6 @@
     "PageColumnNumber": 1,
     "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/create-general-order/draft",
     "RetriesTimeoutURLMidEvent": "120,120",
-    "ShowSummaryChangeOption": "No"
+    "ShowSummaryChangeOption": "Yes"
   }
 ]


### PR DESCRIPTION
I have missed one AC:
```
AC2 General order check your answers
GIVEN a case is in any state
WHEN the caseworker-beta triggers the event 'createGeneralOrder'
AND completes the fields in the 'general order' page
AND clicks on continue
AND they are taken to the 'General order draft' page
AND they click on continue
THEN they are taken to the check your answers page
```

According to CCD documentation this should be enough:
https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=767557735#IntroductiontoCCDConfiguration-UserGuide-k)Summary'CheckYourAnswers'page

Story:
https://tools.hmcts.net/jira/browse/DIV-6142