### PR TITLE
DIV-6479: Allow solicitor to amend from state 'AwaitingAmendCase'

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-pet-amend-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-pet-amend-nonprod.json
@@ -11,7 +11,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingAmendCase",
     "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "03/07/2020",

--- a/definitions/divorce/json/CaseEvent/CaseEvent-pet-amend-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-pet-amend-nonprod.json
@@ -22,5 +22,18 @@
         "PreConditionState(s)": "AosCompleted;AwaitingAmendCase",
         "PostConditionState": "AmendPetition",
         "SecurityClassification": "Public"
+    },
+    {
+      "LiveFrom": "29/06/2020",
+      "CaseTypeID": "DIVORCE",
+      "ID": "amendPetitionForRefusalSol",
+      "Name": "Submit amended application",
+      "Description": "Submit amended application",
+      "DisplayOrder": 3,
+      "PreConditionState(s)": "DNisRefused;Issued;Rejected;PendingRejection;AosAwaiting;AosStarted;AosSubmittedAwaitingAnswer;AwaitingDecreeNisi;AosOverdue;AwaitingReissue;AosCompleted;AosAwaitingSol;AosPreSubmit;AosDrafted;AwaitingService;AwaitingAmendCase",
+      "PostConditionState": "AmendPetition",
+      "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/solicitor-amend-petition-dn-rejection",
+      "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
+      "SecurityClassification": "Public"
     }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-prod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-prod.json
@@ -22,5 +22,18 @@
       "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/petition-updated",
       "RetriesTimeoutURLSubmittedEvent": "120,120",
       "SecurityClassification": "Public"
+    },
+    {
+      "LiveFrom": "29/06/2020",
+      "CaseTypeID": "DIVORCE",
+      "ID": "amendPetitionForRefusalSol",
+      "Name": "Submit amended application",
+      "Description": "Submit amended application",
+      "DisplayOrder": 3,
+      "PreConditionState(s)": "DNisRefused;Issued;Rejected;PendingRejection;AosAwaiting;AosStarted;AosSubmittedAwaitingAnswer;AwaitingDecreeNisi;AosOverdue;AwaitingReissue;AosCompleted;AosAwaitingSol;AosPreSubmit;AosDrafted;AwaitingService",
+      "PostConditionState": "AmendPetition",
+      "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/solicitor-amend-petition-dn-rejection",
+      "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
+      "SecurityClassification": "Public"
     }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent.json
@@ -2654,19 +2654,6 @@
     "SecurityClassification": "Public"
   },
   {
-    "LiveFrom": "29/06/2020",
-    "CaseTypeID": "DIVORCE",
-    "ID": "amendPetitionForRefusalSol",
-    "Name": "Submit amended application",
-    "Description": "Submit amended application",
-    "DisplayOrder": 3,
-    "PreConditionState(s)": "DNisRefused;Issued;Rejected;PendingRejection;AosAwaiting;AosStarted;AosSubmittedAwaitingAnswer;AwaitingDecreeNisi;AosOverdue;AwaitingReissue;AosCompleted;AosAwaitingSol;AosPreSubmit;AosDrafted;AwaitingService",
-    "PostConditionState": "AmendPetition",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/solicitor-amend-petition-dn-rejection",
-    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
-    "SecurityClassification": "Public"
-  },
-  {
     "LiveFrom": "01/01/2019",
     "CaseTypeID": "DIVORCE",
     "ID": "createCase",

--- a/test/unit/definitions/divorce/AuthorisationCaseEvent.test.js
+++ b/test/unit/definitions/divorce/AuthorisationCaseEvent.test.js
@@ -31,7 +31,7 @@ describe('AuthorisationCaseEvent', () => {
 });
 
 describe('AuthorisationCaseEvent', () => {
-  it('should contain a unique case type, case event ID and role (no duplicates) for non-prod', () => {
+  it('should contain a unique case type, case event ID and role (no duplicates) for prod', () => {
     const prodOnly = mergeJsonProdFiles();
     const uniqResult = uniqWith(prodOnly, isFieldDuplicated('CaseEventID'));
 

--- a/test/unit/definitions/divorce/CaseEventToFields.test.js
+++ b/test/unit/definitions/divorce/CaseEventToFields.test.js
@@ -1,36 +1,108 @@
 const { expect, assert } = require('chai');
 const { find } = require('lodash');
 
+const load = require;
 const caseEvent = Object.assign(require('definitions/divorce/json/CaseEvent/CaseEvent'), []);
-const caseField = [].concat(require('definitions/divorce/json/CaseField/CaseField.json'))
-  .concat(require('definitions/divorce/json/CaseField/CaseField-prod.json'));
+const caseField = Object.assign(require('definitions/divorce/json/CaseField/CaseField.json'), []);
 const caseEventToFields = Object.assign(require('definitions/divorce/json/CaseEventToFields/CaseEventToFields'), []);
 
-describe('CaseEventToFields', () => {
-  it('should contain valid event IDs', () => {
-    const errors = [];
-    caseEventToFields.forEach(caseEventToFieldsEntry => {
-      try {
-        expect(find(caseEvent, ['ID', caseEventToFieldsEntry.CaseEventID])).to.be.an('object');
-      } catch (error) {
-        errors.push(`Event ID ${caseEventToFieldsEntry.CaseEventID} is not valid`);
-      }
-    });
-    if (errors.length) {
-      assert.fail(`Found invalid case IDs - ${errors}`);
+function mergeCaseEventJsonNonProdFiles() {
+  const definitions = []
+    .concat(load('definitions/divorce/json/CaseEvent/CaseEvent-deemed-and-dispensed-nonprod.json'))
+    .concat(load('definitions/divorce/json/CaseEvent/CaseEvent-general-order-nonprod.json'))
+    .concat(load('definitions/divorce/json/CaseEvent/CaseEvent-pet-amend-nonprod.json'))
+    .concat(load('definitions/divorce/json/CaseEvent/CaseEvent-nonprod.json'));
+
+  return [...caseEvent, ...definitions];
+}
+
+function mergeCaseEventJsonProdFiles() {
+  const definitions = []
+    .concat(load('definitions/divorce/json/CaseEvent/CaseEvent-prod.json'));
+
+  return [...caseEvent, ...definitions];
+}
+
+function mergeCaseFieldJsonNonProdFiles() {
+  const definitions = []
+    .concat(load('definitions/divorce/json/CaseField/CaseField-deemed-and-dispensed-nonprod.json'))
+    .concat(load('definitions/divorce/json/CaseField/CaseField-general-order-nonprod.json'))
+    .concat(load('definitions/divorce/json/CaseField/CaseField-pcq-nonprod.json'));
+
+  return [...caseField, ...definitions];
+}
+
+function mergeCaseFieldJsonProdFiles() {
+  const definitions = []
+    .concat(load('definitions/divorce/json/CaseField/CaseField-prod.json'));
+
+  return [...caseField, ...definitions];
+}
+
+function mergeCaseEventToFieldsJsonNonProdFiles() {
+  const definitions = []
+    .concat(load('definitions/divorce/json/CaseEventToFields/CaseEventToFields-deemed-and-dispensed-nonprod.json'))
+    .concat(load('definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json'))
+    .concat(load('definitions/divorce/json/CaseEventToFields/CaseEventToFields-nonprod.json'));
+
+  return [...caseEventToFields, ...definitions];
+}
+
+function mergeCaseEventToFieldsJsonProdFiles() {
+  const definitions = []
+    .concat(load('definitions/divorce/json/CaseEventToFields/CaseEventToFields-prod.json'));
+
+  return [...caseEventToFields, ...definitions];
+}
+
+function assertHasOnlyValidEventIds(caseEventToFieldsFile, caseEventFile) {
+  const errors = [];
+  caseEventToFieldsFile.forEach(caseEventToFieldsEntry => {
+    try {
+      expect(find(caseEventFile, ['ID', caseEventToFieldsEntry.CaseEventID])).to.be.an('object');
+    } catch (error) {
+      errors.push(`Event ID ${caseEventToFieldsEntry.CaseEventID} is not valid`);
     }
   });
-  it('should contain valid field IDs', () => {
-    const errors = [];
-    caseEventToFields.forEach(caseEventToFieldsEntry => {
-      try {
-        expect(find(caseField, ['ID', caseEventToFieldsEntry.CaseFieldID])).to.be.an('object');
-      } catch (error) {
-        errors.push(`Field ID ${caseEventToFieldsEntry.CaseFieldID} is not valid`);
-      }
-    });
-    if (errors.length) {
-      assert.fail(`Found invalid field IDs - ${errors}`);
+  if (errors.length) {
+    assert.fail(`Found invalid case IDs - ${errors}`);
+  }
+}
+
+function assertHasOnlyValidFieldIds(caseEventToFieldsFile, caseFieldFile) {
+  const errors = [];
+  caseEventToFieldsFile.forEach(caseEventToFieldsEntry => {
+    try {
+      expect(find(caseFieldFile, ['ID', caseEventToFieldsEntry.CaseFieldID])).to.be.an('object');
+    } catch (error) {
+      errors.push(`Field ID ${caseEventToFieldsEntry.CaseFieldID} is not valid`);
     }
+  });
+  if (errors.length) {
+    assert.fail(`Found invalid field IDs - ${errors}`);
+  }
+}
+
+describe('CaseEventToFields (non-prod)', () => {
+  const caseEventToFieldsNonProd = mergeCaseEventToFieldsJsonNonProdFiles();
+  it('should contain valid event IDs', () => {
+    const caseEventNonProd = mergeCaseEventJsonNonProdFiles();
+    assertHasOnlyValidEventIds(caseEventToFieldsNonProd, caseEventNonProd);
+  });
+  it('should contain valid field IDs', () => {
+    const caseFieldNonProd = mergeCaseFieldJsonNonProdFiles();
+    assertHasOnlyValidFieldIds(caseEventToFieldsNonProd, caseFieldNonProd);
+  });
+});
+
+describe('CaseEventToFields (prod)', () => {
+  const caseEventToFieldsProd = mergeCaseEventToFieldsJsonProdFiles();
+  it('should contain valid event IDs', () => {
+    const caseEventProd = mergeCaseEventJsonProdFiles();
+    assertHasOnlyValidEventIds(caseEventToFieldsProd, caseEventProd);
+  });
+  it('should contain valid field IDs', () => {
+    const caseFieldProd = mergeCaseFieldJsonProdFiles();
+    assertHasOnlyValidFieldIds(caseEventToFieldsProd, caseFieldProd);
   });
 });


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6479

### Change description ###

As a caseworker
If a solicitor gets in touch with the courts saying that want to amend a case,
AND they accidentally trigger the event 'allow petitioner to amend' (which is not required for a solicitor case)
THEN the solicitor is still able to trigger the event 'Submit amended Petition' i.e. the case is not 'dead-ended'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
