### PR TITLE
DIV-6142: '/create-general-order/draft' should be added to page before the draft doc is displayed

### DIFF
--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json
@@ -10,6 +10,8 @@
     "PageLabel": "General order",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/create-general-order/draft",
+    "RetriesTimeoutURLMidEvent": "120,120",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -75,8 +77,6 @@
     "PageLabel": "General order",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/create-general-order/draft",
-    "RetriesTimeoutURLMidEvent": "120,120",
     "ShowSummaryChangeOption": "Yes"
   },
   {

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json
@@ -75,6 +75,8 @@
     "PageLabel": "General order",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/create-general-order/draft",
+    "RetriesTimeoutURLMidEvent": "120,120",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -88,8 +90,6 @@
     "PageLabel": "General order",
     "PageDisplayOrder": 2,
     "PageColumnNumber": 1,
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/create-general-order/draft",
-    "RetriesTimeoutURLMidEvent": "120,120",
     "ShowSummaryChangeOption": "Yes"
   }
 ]


### PR DESCRIPTION
Callback:
```
/create-general-order/draft
```

must be added to page before. Otherwise the document will not be generated when user views this page and it's not working as expected. And this must be added to definition of the first field of that page (`"PageFieldDisplayOrder": 1`).

<img width="656" alt="Screenshot 2020-09-08 at 16 34 57" src="https://user-images.githubusercontent.com/5647337/92491823-f8657600-f1f2-11ea-9de9-fc072e32c9fd.png">


**Story:**
https://tools.hmcts.net/jira/browse/DIV-6142