### PR TITLE
DIV-6142: GeneralOrderDraft on event page should be READONLY

### DIFF
--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json
@@ -85,7 +85,7 @@
     "CaseEventID": "createGeneralOrder",
     "CaseFieldID": "GeneralOrderDraft",
     "PageFieldDisplayOrder": 1,
-    "DisplayContext": "MANDATORY",
+    "DisplayContext": "READONLY",
     "PageID": "generalorderdraft",
     "PageLabel": "General order",
     "PageDisplayOrder": 2,


### PR DESCRIPTION
GeneralOrderDraft should be READONLY, otherwise:
![image](https://user-images.githubusercontent.com/5647337/92608016-21e6d600-f2b5-11ea-9dd4-428705bfb16b.png)
