### PR TITLE
DIV-6240: RetriesTimeoutURLMidEvent moved to the right definition

### DIFF
--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-deemed-and-dispensed-nonprod.json
@@ -51,6 +51,7 @@
     "PageColumnNumber": 1,
     "PageShowCondition": "ServiceApplicationGranted=\"No\"",
     "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/service-decision-made/draft",
+    "RetriesTimeoutURLMidEvent": "120,120",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -65,8 +66,7 @@
     "PageDisplayOrder": 3,
     "PageColumnNumber": 1,
     "PageShowCondition": "ServiceApplicationRefusalReason=\"*\"",
-    "ShowSummaryChangeOption": "No",
-    "RetriesTimeoutURLMidEvent": "120,120"
+    "ShowSummaryChangeOption": "No"
   },
   {
     "LiveFrom": "04/08/2020",

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-deemed-and-dispensed-nonprod.json
@@ -51,7 +51,6 @@
     "PageColumnNumber": 1,
     "PageShowCondition": "ServiceApplicationGranted=\"No\"",
     "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/service-decision-made/draft",
-    "RetriesTimeoutURLMidEvent": "120,120",
     "ShowSummaryChangeOption": "Yes"
   },
   {

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json
@@ -11,7 +11,6 @@
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
     "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/create-general-order/draft",
-    "RetriesTimeoutURLMidEvent": "120,120",
     "ShowSummaryChangeOption": "Yes"
   },
   {

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields.json
@@ -1679,7 +1679,8 @@
     "PageDisplayOrder": 12,
     "PageShowCondition": "D8ReasonForDivorce=\"desertion\"",
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields",
+    "RetriesTimeoutURLMidEvent": "120,120"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -1741,7 +1742,8 @@
     "PageDisplayOrder": 13,
     "PageShowCondition": "D8ReasonForDivorce=\"separation-*\"",
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields",
+    "RetriesTimeoutURLMidEvent": "120,120"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -3329,7 +3331,8 @@
     "PageDisplayOrder": 12,
     "PageShowCondition": "D8ReasonForDivorce=\"desertion\"",
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields",
+    "RetriesTimeoutURLMidEvent": "120,120"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -3391,7 +3394,8 @@
     "PageDisplayOrder": 13,
     "PageShowCondition": "D8ReasonForDivorce=\"separation-*\"",
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields",
+    "RetriesTimeoutURLMidEvent": "120,120"
   },
   {
     "LiveFrom": "05/06/2019",

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields.json
@@ -1679,8 +1679,7 @@
     "PageDisplayOrder": 12,
     "PageShowCondition": "D8ReasonForDivorce=\"desertion\"",
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields",
-    "RetriesTimeoutURLMidEvent": "120,120"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -1742,8 +1741,7 @@
     "PageDisplayOrder": 13,
     "PageShowCondition": "D8ReasonForDivorce=\"separation-*\"",
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields",
-    "RetriesTimeoutURLMidEvent": "120,120"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -3331,8 +3329,7 @@
     "PageDisplayOrder": 12,
     "PageShowCondition": "D8ReasonForDivorce=\"desertion\"",
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields",
-    "RetriesTimeoutURLMidEvent": "120,120"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -3394,8 +3391,7 @@
     "PageDisplayOrder": 13,
     "PageShowCondition": "D8ReasonForDivorce=\"separation-*\"",
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields",
-    "RetriesTimeoutURLMidEvent": "120,120"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/calculate-separation-fields"
   },
   {
     "LiveFrom": "05/06/2019",
@@ -6370,8 +6366,7 @@
     "PageDisplayOrder": 3,
     "PageShowCondition": "RefusalDecision=\"reject\"",
     "ShowSummaryChangeOption": "Yes",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/dn-about-to-be-granted",
-    "RetriesTimeoutURLMidEvent": "120,120"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/dn-about-to-be-granted"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -6398,8 +6393,7 @@
     "PageDisplayOrder": 4,
     "PageShowCondition": "RefusalDecision=\"moreInfo\"",
     "ShowSummaryChangeOption": "Yes",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/dn-about-to-be-granted",
-    "RetriesTimeoutURLMidEvent": "120,120"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/dn-about-to-be-granted"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -6642,8 +6636,7 @@
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition",
-    "RetriesTimeoutURLMidEvent": "120,120"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition"
   },
   {
     "LiveFrom": "16/04/2019",
@@ -7183,8 +7176,7 @@
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition",
-    "RetriesTimeoutURLMidEvent": "120,120"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition"
   },
   {
     "LiveFrom": "16/04/2019",
@@ -7713,8 +7705,7 @@
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "No",
-    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition",
-    "RetriesTimeoutURLMidEvent": "120,120"
+    "CallBackURLMidEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition"
   },
   {
     "LiveFrom": "16/04/2019",

--- a/test/unit/definitions/divorce/CaseEventToFields.test.js
+++ b/test/unit/definitions/divorce/CaseEventToFields.test.js
@@ -103,6 +103,23 @@ function assertEventCallBacksDefinedInTheFirstField (caseEventToFieldsFile) {
   }
 }
 
+function assertRetriesTimeoutURLMidEventIsAddedForAllCallbacks(caseEventToFieldsFile) {
+  const errors = [];
+  caseEventToFieldsFile.forEach(caseEventToFieldsEntry => {
+    try {
+      if (caseEventToFieldsEntry.CallBackURLMidEvent) {
+        expect(caseEventToFieldsEntry.RetriesTimeoutURLMidEvent).to.exist;
+      }
+    } catch (error) {
+      errors.push(`Field ID ${caseEventToFieldsEntry.CaseFieldID} defines callback without RetriesTimeoutURLMidEvent`);
+    }
+  });
+
+  if (errors.length) {
+    assert.fail(`Found invalid field IDs - ${errors}`);
+  }
+}
+
 describe('CaseEventToFields (non-prod)', () => {
   const caseEventToFieldsNonProd = mergeCaseEventToFieldsJsonNonProdFiles();
   it('should contain valid event IDs', () => {
@@ -128,7 +145,12 @@ describe('CaseEventToFields (prod)', () => {
     const caseFieldProd = mergeCaseFieldJsonProdFiles();
     assertHasOnlyValidFieldIds(caseEventToFieldsProd, caseFieldProd);
   });
-  it('CallBackURLMidEvent if defined is added to the first field on page', () => {
-    assertEventCallBacksDefinedInTheFirstField(caseEventToFieldsProd);
+  describe('CallBackURLMidEvent', () => {
+    it('(if defined) is added to the first field on page', () => {
+      assertEventCallBacksDefinedInTheFirstField(caseEventToFieldsProd);
+    });
+    it('has RetriesTimeoutURLMidEvent defined as well', () => {
+      assertRetriesTimeoutURLMidEventIsAddedForAllCallbacks(caseEventToFieldsProd);
+    });
   });
 });

--- a/test/unit/definitions/divorce/CaseEventToFields.test.js
+++ b/test/unit/definitions/divorce/CaseEventToFields.test.js
@@ -6,7 +6,7 @@ const caseEvent = Object.assign(require('definitions/divorce/json/CaseEvent/Case
 const caseField = Object.assign(require('definitions/divorce/json/CaseField/CaseField.json'), []);
 const caseEventToFields = Object.assign(require('definitions/divorce/json/CaseEventToFields/CaseEventToFields'), []);
 
-function mergeCaseEventJsonNonProdFiles () {
+function mergeCaseEventJsonNonProdFiles() {
   const definitions = []
     .concat(load('definitions/divorce/json/CaseEvent/CaseEvent-deemed-and-dispensed-nonprod.json'))
     .concat(load('definitions/divorce/json/CaseEvent/CaseEvent-general-order-nonprod.json'))
@@ -17,14 +17,14 @@ function mergeCaseEventJsonNonProdFiles () {
   return [...caseEvent, ...definitions];
 }
 
-function mergeCaseEventJsonProdFiles () {
+function mergeCaseEventJsonProdFiles() {
   const definitions = []
     .concat(load('definitions/divorce/json/CaseEvent/CaseEvent-prod.json'));
 
   return [...caseEvent, ...definitions];
 }
 
-function mergeCaseFieldJsonNonProdFiles () {
+function mergeCaseFieldJsonNonProdFiles() {
   const definitions = []
     .concat(load('definitions/divorce/json/CaseField/CaseField-deemed-and-dispensed-nonprod.json'))
     .concat(load('definitions/divorce/json/CaseField/CaseField-general-order-nonprod.json'))
@@ -34,14 +34,14 @@ function mergeCaseFieldJsonNonProdFiles () {
   return [...caseField, ...definitions];
 }
 
-function mergeCaseFieldJsonProdFiles () {
+function mergeCaseFieldJsonProdFiles() {
   const definitions = []
     .concat(load('definitions/divorce/json/CaseField/CaseField-prod.json'));
 
   return [...caseField, ...definitions];
 }
 
-function mergeCaseEventToFieldsJsonNonProdFiles () {
+function mergeCaseEventToFieldsJsonNonProdFiles() {
   const definitions = []
     .concat(load('definitions/divorce/json/CaseEventToFields/CaseEventToFields-deemed-and-dispensed-nonprod.json'))
     .concat(load('definitions/divorce/json/CaseEventToFields/CaseEventToFields-general-order-nonprod.json'))
@@ -51,14 +51,14 @@ function mergeCaseEventToFieldsJsonNonProdFiles () {
   return [...caseEventToFields, ...definitions];
 }
 
-function mergeCaseEventToFieldsJsonProdFiles () {
+function mergeCaseEventToFieldsJsonProdFiles() {
   const definitions = []
     .concat(load('definitions/divorce/json/CaseEventToFields/CaseEventToFields-prod.json'));
 
   return [...caseEventToFields, ...definitions];
 }
 
-function assertHasOnlyValidEventIds (caseEventToFieldsFile, caseEventFile) {
+function assertHasOnlyValidEventIds(caseEventToFieldsFile, caseEventFile) {
   const errors = [];
   caseEventToFieldsFile.forEach(caseEventToFieldsEntry => {
     try {
@@ -72,7 +72,7 @@ function assertHasOnlyValidEventIds (caseEventToFieldsFile, caseEventFile) {
   }
 }
 
-function assertHasOnlyValidFieldIds (caseEventToFieldsFile, caseFieldFile) {
+function assertHasOnlyValidFieldIds(caseEventToFieldsFile, caseFieldFile) {
   const errors = [];
   caseEventToFieldsFile.forEach(caseEventToFieldsEntry => {
     try {
@@ -86,7 +86,7 @@ function assertHasOnlyValidFieldIds (caseEventToFieldsFile, caseFieldFile) {
   }
 }
 
-function assertEventCallBacksDefinedInTheFirstField (caseEventToFieldsFile) {
+function assertEventCallBacksDefinedInTheFirstField(caseEventToFieldsFile) {
   const errors = [];
   caseEventToFieldsFile.forEach(caseEventToFieldsEntry => {
     try {
@@ -108,7 +108,7 @@ function assertRetriesTimeoutURLMidEventIsAddedForAllCallbacks(caseEventToFields
   caseEventToFieldsFile.forEach(caseEventToFieldsEntry => {
     try {
       // this field is ignored by CCD
-      expect(caseEventToFieldsEntry.RetriesTimeoutURLMidEvent).not.to.exist;
+      expect(caseEventToFieldsEntry.RetriesTimeoutURLMidEvent).not.to.be.an('string');
     } catch (error) {
       errors.push(`Field ID ${caseEventToFieldsEntry.CaseFieldID} defines callback without RetriesTimeoutURLMidEvent\n`);
     }

--- a/test/unit/definitions/divorce/CaseEventToFields.test.js
+++ b/test/unit/definitions/divorce/CaseEventToFields.test.js
@@ -107,11 +107,10 @@ function assertRetriesTimeoutURLMidEventIsAddedForAllCallbacks(caseEventToFields
   const errors = [];
   caseEventToFieldsFile.forEach(caseEventToFieldsEntry => {
     try {
-      if (caseEventToFieldsEntry.CallBackURLMidEvent) {
-        expect(caseEventToFieldsEntry.RetriesTimeoutURLMidEvent).to.exist;
-      }
+      // this field is ignored by CCD
+      expect(caseEventToFieldsEntry.RetriesTimeoutURLMidEvent).not.to.exist;
     } catch (error) {
-      errors.push(`Field ID ${caseEventToFieldsEntry.CaseFieldID} defines callback without RetriesTimeoutURLMidEvent`);
+      errors.push(`Field ID ${caseEventToFieldsEntry.CaseFieldID} defines callback without RetriesTimeoutURLMidEvent\n`);
     }
   });
 
@@ -130,8 +129,13 @@ describe('CaseEventToFields (non-prod)', () => {
     const caseFieldNonProd = mergeCaseFieldJsonNonProdFiles();
     assertHasOnlyValidFieldIds(caseEventToFieldsNonProd, caseFieldNonProd);
   });
-  it('CallBackURLMidEvent if defined is added to the first field on page', () => {
-    assertEventCallBacksDefinedInTheFirstField(caseEventToFieldsNonProd);
+  describe('CallBackURLMidEvent', () => {
+    it('(if defined) is added to the first field on page', () => {
+      assertEventCallBacksDefinedInTheFirstField(caseEventToFieldsNonProd);
+    });
+    it('RetriesTimeoutURLMidEvent is never defined', () => {
+      assertRetriesTimeoutURLMidEventIsAddedForAllCallbacks(caseEventToFieldsNonProd);
+    });
   });
 });
 
@@ -149,7 +153,7 @@ describe('CaseEventToFields (prod)', () => {
     it('(if defined) is added to the first field on page', () => {
       assertEventCallBacksDefinedInTheFirstField(caseEventToFieldsProd);
     });
-    it('has RetriesTimeoutURLMidEvent defined as well', () => {
+    it('RetriesTimeoutURLMidEvent is never defined', () => {
       assertRetriesTimeoutURLMidEventIsAddedForAllCallbacks(caseEventToFieldsProd);
     });
   });


### PR DESCRIPTION
`RetriesTimeoutURLMidEvent` should not be used at all.

This field is ignored by CCD.

https://github.com/hmcts/ccd-data-store-api/blob/97778561b9327f05eb16bd349b24d48c0ad6171a/src/main/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackService.java#L46