### PR TITLE
DIV-6142: use CallBackURLAboutToSubmitEvent instead of CallBackURLSubmittedEvent

### DIFF
--- a/definitions/divorce/json/CaseEvent/CaseEvent-general-order-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-general-order-nonprod.json
@@ -8,8 +8,7 @@
     "DisplayOrder": 14,
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
-    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/create-general-order/final",
-    "RetriesTimeoutURLSubmittedEvent": "120,120",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/create-general-order/final",
     "SecurityClassification": "Public"
   }
 ]


### PR DESCRIPTION
We need to save data in ccd. So that `CallBackURLAboutToSubmitEvent` callback must be used since `CallBackURLSubmittedEvent` will not update case date with response from callback.