### PR TITLE
Move Authorisation for pcqextractor to non-prod

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-deemed-and-dispensed-nonprod.json
@@ -173,5 +173,19 @@
     "CaseStateID": "AwaitingServicePayment",
     "UserRole": "caseworker-divorce-pcqextractor",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "14/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AwaitingServiceConsideration",
+    "UserRole": "caseworker-divorce-pcqextractor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "14/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "ServiceApplicationNotApproved",
+    "UserRole": "caseworker-divorce-pcqextractor",
+    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-deemed-and-dispensed-nonprod.json
@@ -166,5 +166,12 @@
     "CaseStateID": "ServiceApplicationNotApproved",
     "UserRole": "caseworker-divorce-courtadmin-la",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "14/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AwaitingServicePayment",
+    "UserRole": "caseworker-divorce-pcqextractor",
+    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -2546,12 +2546,5 @@
     "CaseStateID": "WelshDNReceived",
     "UserRole": "caseworker-divorce-pcqextractor",
     "CRUD": "R"
-  },
-  {
-    "LiveFrom": "14/09/2020",
-    "CaseTypeID": "DIVORCE",
-    "CaseStateID": "AwaitingServicePayment",
-    "UserRole": "caseworker-divorce-pcqextractor",
-    "CRUD": "R"
   }
 ]


### PR DESCRIPTION
+ Move authorisation for caseworker-divorce-pcqextractor on AwaitingServicePayment from prod to non-prod because the state is not created in prod-files yet.

Due to the following: https://github.com/hmcts/div-ccd-definitions/pull/478

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
