### PR TITLE
DIV-6509: Add ServiceApplicationNotApproved

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-deemed-and-dispensed-nonprod.json
@@ -159,5 +159,327 @@
     "CaseEventID": "startAosFromServiceAppRejected",
     "UserRole": "citizen",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "aosNotReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "aosNotReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "aosNotReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "aosNotReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "aosNotReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solAosNotReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solAosNotReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solAosNotReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solAosNotReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solAosNotReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "answerReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "answerReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "answerReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "answerReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "answerReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "answerReceivedFromServiceAppRejected",
+    "UserRole": "citizen",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "coRespAnswerReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "coRespAnswerReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "coRespAnswerReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "coRespAnswerReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "coRespAnswerReceivedFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "coRespAnswerReceivedFromServiceAppRejected",
+    "UserRole": "citizen",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_Respondent_FromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_Respondent_FromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_Respondent_FromServiceAppRejected",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_Respondent_FromServiceAppRejected",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_Respondent_FromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_Respondent_FromServiceAppRejected",
+    "UserRole": "citizen",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_CoRespondent_FromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_CoRespondent_FromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_CoRespondent_FromServiceAppRejected",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_CoRespondent_FromServiceAppRejected",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_CoRespondent_FromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "IssueAOSOffline_CoRespondent_FromServiceAppRejected",
+    "UserRole": "citizen",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "reissueFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "reissueFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "reissueFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "reissueFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "reissueFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "reissueFromServiceAppRejected",
+    "UserRole": "citizen",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromServiceAppRejected",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromServiceAppRejected",
+    "UserRole": "citizen",
+    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-deemed-and-dispensed-nonprod.json
@@ -143,6 +143,17 @@
     "SecurityClassification": "Public"
   },
   {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "transferCaseFromServiceAppRejected",
+    "Name": "Transfer from CTSC to RDC",
+    "Description": "Transfer from CTSC to RDC",
+    "DisplayOrder": 12,
+    "PreConditionState(s)": "ServiceApplicationNotApproved",
+    "PostConditionState": "Issued",
+    "SecurityClassification": "Public"
+  },
+  {
     "LiveFrom": "18/09/2020",
     "CaseTypeID": "DIVORCE",
     "ID": "startAosFromServiceAppRejected",
@@ -152,5 +163,85 @@
     "PreConditionState(s)": "ServiceApplicationNotApproved",
     "PostConditionState": "AosStarted",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "aosNotReceivedFromServiceAppRejected",
+    "Name": "AOS Not Received within SLA",
+    "Description": "AOS Not Received within SLA",
+    "DisplayOrder": 4,
+    "PreConditionState(s)": "ServiceApplicationNotApproved",
+    "PostConditionState": "AosOverdue",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "solAosNotReceivedFromServiceAppRejected",
+    "Name": "AOS Not Received within SLA",
+    "Description": "AOS Not Received within SLA",
+    "DisplayOrder": 5,
+    "PreConditionState(s)": "ServiceApplicationNotApproved",
+    "PostConditionState": "AosOverdue",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "answerReceivedFromServiceAppRejected",
+    "Name": "Answer received",
+    "Description": "Answer received",
+    "DisplayOrder": 7,
+    "PreConditionState(s)": "ServiceApplicationNotApproved",
+    "PostConditionState": "DefendedDivorce",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "coRespAnswerReceivedFromServiceAppRejected",
+    "Name": "Answer received",
+    "Description": "Answer received",
+    "DisplayOrder": 8,
+    "PreConditionState(s)": "ServiceApplicationNotApproved",
+    "PostConditionState": "ServiceApplicationNotApproved",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "IssueAOSOffline_Respondent_FromServiceAppRejected",
+    "Name": "Issue AOS pack to respondent",
+    "Description": "Answer received",
+    "DisplayOrder": 9,
+    "PreConditionState(s)": "ServiceApplicationNotApproved",
+    "PostConditionState": "AosAwaiting",
+    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "IssueAOSOffline_CoRespondent_FromServiceAppRejected",
+    "Name": "Issue AOS pack - Co-respondent",
+    "Description": "Answer received",
+    "DisplayOrder": 10,
+    "PreConditionState(s)": "ServiceApplicationNotApproved",
+    "PostConditionState": "ServiceApplicationNotApproved",
+    "SecurityClassification": "Public",
+    "ShowSummary": "Y"
+  },
+  {
+    "LiveFrom": "16/09/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "reissueFromServiceAppRejected",
+    "Name": "Reissue petition",
+    "Description": "Reissue petition",
+    "DisplayOrder": 11,
+    "PreConditionState(s)": "ServiceApplicationNotApproved",
+    "PostConditionState": "AwaitingReissue",
+    "SecurityClassification": "Public",
+    "ShowSummary": "Y"
   }
 ]


### PR DESCRIPTION
it's the same we have here:
https://github.com/hmcts/div-ccd-definitions/pull/487

But PR-487 is making weird things and I want to see if this can be built properly on different PR.

Story:
https://tools.hmcts.net/jira/browse/DIV-6509


### Change description ###

Add with Permissions:

|CaseEvent|Admin|Beta|La|Sol|Super|Cit
-- |-- | --| -- |--|--|--
|aosNotReceivedFromServiceAppRejected| R | CRU | R | R | R | - 
|solAosNotReceivedFromServiceAppRejected| R | R | R | CRU | R | - 
|startAosFromServiceAppRejected| R | CRU | R | R | R | CRU 
|answerReceivedFromServiceAppRejected| R | CRU | R | R | R | R 
|coRespAnswerReceivedFromServiceAppRejected| R | CRU | R | R | R | R 
|IssueAOSOffline_Respondent_FromServiceAppRejected| R | CRU | R | R | R | R 
|IssueAOSOffline_CoRespondent_FromServiceAppRejected| R | CRU | R | R | R | R 
|reissueFromServiceAppRejected| R | CRU | R | R | R | R 
|transferCaseFromServiceAppRejected| R | CRU | R | R | R | R 


ACs |  
-- | --
1 | "CallBackURLSubmittedEvent":   "${CCD_DEF_COS_URL}/petition-updated",
2 | "CallBackURLSubmittedEvent":   "${CCD_DEF_COS_URL}/petition-updated",
3 | "CallBackURLSubmittedEvent":   "${CCD_DEF_COS_URL}/petition-updated",
4 * | "CallBackURLSubmittedEvent":   "${CCD_DEF_COS_URL}/petition-updated",
5 * | "CallBackURLAboutToSubmitEvent":   "${CCD_DEF_COS_URL}/co-respondent-answered",
6 * | "CallBackURLAboutToSubmitEvent":   "${CCD_DEF_COS_URL}/issue-aos-pack-offline/parties/respondent",
7 * | "CallBackURLAboutToSubmitEvent":   "${CCD_DEF_COS_URL}/issue-aos-pack-offline/parties/co-respondent",
8 | "CallBackURLAboutToSubmitEvent":   "${CCD_DEF_COS_URL}/petition-issued?generateAosInvitation=true",

# Testing Criteria
|*Testing Criteria*|*Pass/Fail*|Comment|
-- | -- | ---
|As a caseworker, If the case is in the state 'ServiceApplicationNotApproved', and the petitioner is NOT represented then the event AOS Not Received within SLA can be seen from the dropdown| ✅  |N/A|
|As a caseworker, If the case is in the state 'ServiceApplicationNotApproved', and the petitioner is represented then the event AOS Not Received within SLA can be seen from the dropdown| ✅ |N/A|
|In Swagger, As a respondent, If a case is in the state 'ServiceApplicationNotApproved' and 'pin' and 'caseID' (triggering the new event 'startAosFromServiceAppRejected' then the case state should change to 'AOSStarted'| |N/A|
|In Swagger, If a case is in the state 'ServiceApplicationNotApproved', and answers received from Respondent (using the new event 'answerReceivedFromServiceAppRejected' then case is moved into state 'Defend divorce'| |N/A|
|in Swagger, If a case is in the state 'ServiceApplicationNotApproved', and answers received from Co-respondent (using the new event 'coRespAnswerReceivedFromServiceAppRejected' then case stays in the state 'ServiceApplicationNotApproved'| |N/A|
|As a caseworker, If the case is in the state 'ServiceApplicationNotApproved' then the event 'Issue AOS pack to respondent' can be seen from the dropdown| ✅ |N/A|
|As a caseworker, If the case is in the state 'ServiceApplicationNotApproved' then the event 'Issue AOS pack to Co-respondent' can be seen from the dropdown| ✅ |N/A|
|As a caseworker, If the case is in the state 'ServiceApplicationNotApproved' then the event 'Reissue petition' can be seen from the dropdown| ✅ |N/A|
|As a caseworker, If the case is in the state 'ServiceApplicationNotApproved' then the event 'Transfer from CTSC to RDC', can be seen from the dropdown| ✅ |N/A|
