### PR TITLE
DIV-6504: 'co-respondent' -> 'corespondent'

### DIFF
--- a/definitions/divorce/json/FixedLists/FixedLists-general-order-nonprod.json
+++ b/definitions/divorce/json/FixedLists/FixedLists-general-order-nonprod.json
@@ -2,7 +2,7 @@
   {
     "LiveFrom": "27/08/2020",
     "ID": "DivorcePartiesEnum",
-    "ListElementCode": "co-respondent",
+    "ListElementCode": "corespondent",
     "ListElement": "Co-respondent"
   },
   {


### PR DESCRIPTION
All 'co-responent'`s fixed list values that are not on prod are changed to "corespondent".