### PR TITLE
Update FieldTypeParameter to make more generic

### DIFF
--- a/definitions/divorce/json/CaseField/CaseField-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/CaseField/CaseField-deemed-and-dispensed-nonprod.json
@@ -73,7 +73,7 @@
     "Label": "How will payment be made?",
     "HintText": "How will payment be made?",
     "FieldType": "FixedList",
-    "FieldTypeParameter": "ServiceApplicationPaymentTypeEnum",
+    "FieldTypeParameter": "PaymentTypeEnum",
     "SecurityClassification": "Public"
   },
   {

--- a/definitions/divorce/json/ComplexTypes/ComplexTypes-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/ComplexTypes/ComplexTypes-deemed-and-dispensed-nonprod.json
@@ -29,7 +29,7 @@
     "ID": "DivorceServiceApplication",
     "ListElementCode": "Payment",
     "FieldType": "FixedList",
-    "FieldTypeParameter": "ServiceApplicationPaymentTypeEnum",
+    "FieldTypeParameter": "PaymentTypeEnum",
     "ElementLabel": "How will payment be made?",
     "SecurityClassification": "Public"
   },

--- a/definitions/divorce/json/FixedLists/FixedLists.json
+++ b/definitions/divorce/json/FixedLists/FixedLists.json
@@ -1240,28 +1240,28 @@
   },
   {
     "LiveFrom": "03/08/2020",
-    "ID": "ServiceApplicationPaymentTypeEnum",
+    "ID": "PaymentTypeEnum",
     "ListElementCode": "feeAccount",
     "ListElement": "Fee account",
     "DisplayOrder": 1
   },
   {
     "LiveFrom": "03/08/2020",
-    "ID": "ServiceApplicationPaymentTypeEnum",
+    "ID": "PaymentTypeEnum",
     "ListElementCode": "helpWithFees",
     "ListElement": "Help with Fees",
     "DisplayOrder": 2
   },
   {
     "LiveFrom": "03/08/2020",
-    "ID": "ServiceApplicationPaymentTypeEnum",
+    "ID": "PaymentTypeEnum",
     "ListElementCode": "telephone",
     "ListElement": "Telephone",
     "DisplayOrder": 3
   },
   {
     "LiveFrom": "03/08/2020",
-    "ID": "ServiceApplicationPaymentTypeEnum",
+    "ID": "PaymentTypeEnum",
     "ListElementCode": "cheque",
     "ListElement": "Cheque",
     "DisplayOrder": 4


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DIV-6166


### Change description ###
This change will change `ServiceApplicationPaymentTypeEnum` to `PaymentTypeEnum`.
This is so that two files under feature toggle can use the same information

This is needed to satisfy below.

AC4: Select payment type
GIVEN a case is in the state 'AwaitingGeneralReferralPayment'
WHEN a caseworker triggers the event 'General referral payment'
THEN General referral payment screen show
AND the caseworker is able to select which payment type has been used from a 'how will payment be made?' fixed list. This list includes 'Fee account';'Help with fees'; 'Cheque'; 'Telephone' (this requires a new fixed list in CCD for serviceApplicationPaymentType).

AC5: Selecting fee account from payment type
GIVEN a caseworker has triggered the event 'General referral payment'
WHEN a caseworker selects 'Fee account'
THEN the field 'Enter your account number' (PBA number) and 'Enter your reference' fields display
AND 'Enter your account number' is mandatory and 'Enter your reference' is optional

AC6: Selecting help with fees from payment type
GIVEN a caseworker has triggered the event 'General referral payment'
WHEN a caseworker selects 'Help with fees' 
THEN 'Help with fees reference' field displays
AND 'Help with fees reference field' is mandatory

AC7: Selecting cheque from payment type
GIVEN a caseworker has triggered the event 'General referral payment'
WHEN a caseworker selects 'Cheque'
THEN no further fields display

AC8: Selecting telephone from payment type
GIVEN a caseworker has triggered the event 'General referral payment'
WHEN a caseworker selects 'Telephone'
THEN no further fields display




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
