### PR TITLE
[DO NOT MERGE] DIV-6228-Move event and update prestates for aosSubmittedDefended

### DIFF
--- a/definitions/divorce/json/CaseEvent/CaseEvent-caseworker-LA-Baliff-journey-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-caseworker-LA-Baliff-journey-nonprod.json
@@ -1,0 +1,17 @@
+[
+  {
+    "LiveFrom": "23/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "aosSubmittedDefended",
+    "Name": "AOS Submitted (defending)",
+    "Description": "AOS Submitted (defending)",
+    "DisplayOrder": 2,
+    "PreConditionState(s)": "AosStarted;AosOverdue;ServiceApplicationNotApproved;AwaitingBailiffService;IssuedToBailiff",
+    "PostConditionState": "AosSubmittedAwaitingAnswer",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/aos-received",
+    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/aos-submitted",
+    "RetriesTimeoutURLSubmittedEvent": "120,120",
+    "SecurityClassification": "Public"
+  }
+]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-deemed-and-dispensed-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-deemed-and-dispensed-nonprod.json
@@ -73,21 +73,6 @@
   {
     "LiveFrom": "15/09/2020",
     "CaseTypeID": "DIVORCE",
-    "ID": "aosSubmittedDefended",
-    "Name": "AOS Submitted (defending)",
-    "Description": "AOS Submitted (defending)",
-    "DisplayOrder": 2,
-    "PreConditionState(s)": "AosStarted;AosOverdue;ServiceApplicationNotApproved",
-    "PostConditionState": "AosSubmittedAwaitingAnswer",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/aos-received",
-    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
-    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/aos-submitted",
-    "RetriesTimeoutURLSubmittedEvent": "120,120",
-    "SecurityClassification": "Public"
-  },
-  {
-    "LiveFrom": "15/09/2020",
-    "CaseTypeID": "DIVORCE",
     "ID": "aosReceivedNoAdConStarted",
     "Name": "AOS Received (no ad/con)",
     "Description": "AOS Received (no admission/consent)",

--- a/test/unit/definitions/divorce/CaseEvent.test.js
+++ b/test/unit/definitions/divorce/CaseEvent.test.js
@@ -39,6 +39,7 @@ describe('CaseEvent', () => {
         'CaseEvent-deemed-and-dispensed-nonprod',
         'CaseEvent-general-email-nonprod',
         'CaseEvent-general-referral-nonprod',
+        'CaseEvent-caseworker-LA-Baliff-journey-nonprod',
         'CaseEvent-nonprod'
       ]);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DIV-6229


### Change description ###

Update Event for "aosSubmittedDefended",
to include new prestates.
 "PreConditionState(s)": "AosStarted;AosOverdue;ServiceApplicationNotApproved;AwaitingBailiffService;IssuedToBailiff",

### Do not Merge reason ###
This is also not to be merge until `deemed-and-dispensed-nonprod` has been merged into prod. 
This is because the event was removed from the `CaseEvent-deemed-and-dispensed-nonprod.json` file due to an intentional limitation within ccd-definitions to prevent duplicate entries in nonprod files.