### PR TITLE
RPET-579 restrict when solicitors can upload docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "ccdUrl": "http://ccd-data-store-api-demo.service.core-compute-demo.internal"
     },
     "aat": {
-      "cosUrl": "http://div-cos-aat.service.core-compute-aat.internal",
+      "cosUrl": "https://div-cos-pr-1154.service.core-compute-preview.internal",
       "ccdUrl": "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     },
     "ithc": {


### PR DESCRIPTION

### JIRA link ###
[RPET-579](https://tools.hmcts.net/jira/browse/RPET-579)


### Change description ###
Restrict what states solicitors can upload documents from.
