### PR TITLE
DIV-6726: Bringing file generation parameters from CCD config file in…

### DIFF
--- a/definitions/bulk-action/json/CaseEvent.json
+++ b/definitions/bulk-action/json/CaseEvent.json
@@ -114,7 +114,7 @@
     "PreConditionState(s)": "Listed",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/generate-document?templateId=FL-DIV-GNO-ENG-00059.docx&documentType=caseListForPronouncement&filename=caseListForPronouncement",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/prepare-to-print-for-pronouncement",
     "ShowSummary": "Y"
   },
   {

--- a/definitions/divorce/json/CaseEvent/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent.json
@@ -1734,7 +1734,7 @@
     "DisplayOrder": 21,
     "PreConditionState(s)": "AwaitingPronouncement",
     "PostConditionState": "AwaitingPronouncement",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/generate-document?templateId=FL-DIV-GNO-ENG-00020.docx&documentType=coe&filename=certificateOfEntitlement",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/update-bulk-case-hearing-details",
     "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
     "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/case-linked-for-hearing",
     "RetriesTimeoutURLSubmittedEvent": "120,120",


### PR DESCRIPTION
…to COS.

### Change description ###
The idea here is to make sure document re-generation is precise.
This can only be merged once we're sure that https://github.com/hmcts/div-case-orchestration-service/pull/1183 is in production.
After this is merged, we'll need to open a request to have it deployed to prod.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
