### PR TITLE
DIV-6740: Diverting traffic from event to a specific endpoint (not pa…

### DIFF
--- a/definitions/bulk-action/json/CaseEvent.json
+++ b/definitions/bulk-action/json/CaseEvent.json
@@ -152,7 +152,7 @@
     "DisplayOrder": 9,
     "PreConditionState(s)": "Listed",
     "PostConditionState": "ScheduledForListing",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/bulk/edit/listing?templateId=FL-DIV-GNO-ENG-00059.docx&documentType=caseListForPronouncement&filename=caseListForPronouncement",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/about-to-edit-bulk-case",
     "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
     "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/bulk/schedule/listing",
     "RetriesTimeoutURLSubmittedEvent": "120,120",


### PR DESCRIPTION
…rameterised).

### Change description ###
The idea here is to divert calls that have parameters set in CCD-definitions to this endpoint. After a month or so with use in the old endpoint, I think we can safely remove it for good.

This should be merged until:
- https://github.com/hmcts/div-case-orchestration-service/pull/1204 is merged and deployed to production.
- This is manually tested to make sure that document is still produced when event is triggered.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
