### PR TITLE
DIV-6710: Implementing tabs for resp-solicitor

### DIFF
--- a/definitions/divorce/json/CaseTypeTab/CaseTypeTab-resp-journey-roles-and-permissions-nonprod.json
+++ b/definitions/divorce/json/CaseTypeTab/CaseTypeTab-resp-journey-roles-and-permissions-nonprod.json
@@ -45,6 +45,48 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "Channel": "CaseWorker",
+    "TabID": "confidentialRespondentForRespSol",
+    "TabLabel": "Confidential Respondent",
+    "TabDisplayOrder": 16,
+    "CaseFieldID": "D8DerivedRespondentHomeAddress",
+    "UserRole": "[RESPSOLICITOR]",
+    "TabFieldDisplayOrder": 1,
+    "TabShowCondition": "RespondentContactDetailsConfidential=\"keep\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialRespondentForRespSol",
+    "TabLabel": "Confidential Respondent",
+    "TabDisplayOrder": 16,
+    "CaseFieldID": "D8DerivedRespondentCorrespondenceAddr",
+    "TabFieldDisplayOrder": 2
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialRespondentForRespSol",
+    "TabLabel": "Confidential Respondent",
+    "TabDisplayOrder": 16,
+    "CaseFieldID": "RespEmailAddress",
+    "TabFieldDisplayOrder": 3
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialRespondentForRespSol",
+    "TabLabel": "Confidential Respondent",
+    "TabDisplayOrder": 16,
+    "CaseFieldID": "RespPhoneNumber",
+    "TabFieldDisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
     "TabID": "notesCitizen",
     "TabLabel": "Notes",
     "TabDisplayOrder": 20,

--- a/test/unit/utils/caseTabTypeHelper.js
+++ b/test/unit/utils/caseTabTypeHelper.js
@@ -50,6 +50,7 @@ const nonProdTabIds = [
   'confidentialRespondentCourtAdmin',
   'confidentialRespondentCourtAdminBeta',
   'confidentialRespondentCourtAdminLa',
+  'confidentialRespondentForRespSol',
   'confidentialCoRespondentCourtAdmin',
   'confidentialCoRespondentCourtAdminBeta',
   'confidentialCoRespondentCourtAdminLa',


### PR DESCRIPTION
### Change description ###
All ACs implemented, except for "Service Application" tab (which needs a further decision).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
