### PR TITLE
DIV-6637 Allow a case with state - State Update

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-share-a-case-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-share-a-case-nonprod.json
@@ -5,5 +5,19 @@
     "CaseStateID": "SOTAgreementPayAndSubmitRequired",
     "UserRole": "caseworker-caa",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "30/10/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "Submitted",
+    "UserRole": "caseworker-caa",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "solicitorAwaitingPaymentConfirmation",
+    "UserRole": "caseworker-caa",
+    "CRUD": "CRU"
   }
 ]

--- a/test/unit/definitions/divorce/UserRoleStateAuth.test.js
+++ b/test/unit/definitions/divorce/UserRoleStateAuth.test.js
@@ -11,7 +11,7 @@ const AuthorisationCaseType = getAuthorisationCaseTypeDefinitions(['Authorisatio
 const State = getStatesDefinitions(['State']);
 
 const MINIMUM_READ_PERMISSIONS = /C?RU?D?/;
-const EXCLUDED_STATES = ['SOTAgreementPayAndSubmitRequired', 'Rejected', 'Withdrawn', 'solicitorAwaitingPaymentConfirmation'];
+const EXCLUDED_STATES = ['SOTAgreementPayAndSubmitRequired', 'Rejected', 'Withdrawn', 'solicitorAwaitingPaymentConfirmation', 'Submitted'];
 
 function byCaseType(caseType) {
   return entry => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DIV-6637


### Change description ###

When the `solicitorStatementOfTruthPaySubmit` event is triggered by the solicitor when they about to submit a case
`{
    "ID": "solicitorStatementOfTruthPaySubmit",
    "Name": "Case submission",
    "Description": "Agree Statement of Truth, Pay & Submit",
    "PreConditionState(s)": "SOTAgreementPayAndSubmitRequired",
    "PostConditionState": "*",
    "CallBackURLAboutToStartEvent": "${CCD_DEF_COS_URL}/petition-issue-fees",
    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/process-pba-payment",
    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/allow-share-a-case",
 }
`
There are about 3 possible states the case can end up depending on if it's a `FeeAccount`, `HWF` or some other forms of payment. At the time the case is being assigned in the `CallBackURLSubmittedEvent` the `caseworker-caa` permissions needs to exist for any of these states so the case can be assigned  as at this point the state the case is in needs to have `caa` role for the assignment to be succesful

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
