### PR TITLE
Removing extra condition

### DIFF
--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-resp-journey-roles-and-permissions-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-resp-journey-roles-and-permissions-nonprod.json
@@ -112,7 +112,7 @@
     "PageID": "RespondentServiceDetails",
     "PageLabel": "Respondent service details",
     "PageDisplayOrder": 4,
-    "FieldShowCondition": "respondentSolicitorRepresented=\"Yes\" AND RespSolDigital=\"Yes\"",
+    "FieldShowCondition": "RespSolDigital=\"Yes\"",
     "ShowSummaryChangeOption": "Yes"
   },
   {
@@ -1242,7 +1242,7 @@
     "PageID": "RespondentServiceDetails",
     "PageLabel": "Respondent service details",
     "PageDisplayOrder": 4,
-    "FieldShowCondition": "respondentSolicitorRepresented=\"Yes\" AND RespSolDigital=\"Yes\"",
+    "FieldShowCondition": "RespSolDigital=\"Yes\"",
     "ShowSummaryChangeOption": "Yes"
   },
   {


### PR DESCRIPTION
### Change description ###

The FieldShowCondition of Respondent organisation policy fields was updated in https://github.com/hmcts/div-ccd-definitions/pull/682/files.
This was to not show those fields in the unlikely scenario where the user would do the following:
-  Click "Yes" to the question: Is the respondent represented by a solicitor?
- Click "Yes" to:  digital respondent case
- (They change their mind) and Click "No" to the question: Is the respondent represented by a solicitor?
- In this scenario, the respondent organisation field would still show on the screen (Unless they go back to set "Digital respondent case" to "No")

![image](https://user-images.githubusercontent.com/16866068/107510563-08b3bf80-6b9c-11eb-8bd1-15a2970b02ba.png)

![image](https://user-images.githubusercontent.com/16866068/107510314-a65abf00-6b9b-11eb-96ca-ede366d4f437.png)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
