### PR TITLE
DIV-6723: Add UpdatePetSolContactDetails event and page

### DIFF
--- a/charts/div-ccd-definitions/values.preview.template.yaml
+++ b/charts/div-ccd-definitions/values.preview.template.yaml
@@ -91,6 +91,7 @@ ccd:
         DM_URL: https://gateway-${SERVICE_FQDN}/documents
         DM_URL_REMOTE: https?://(gateway-${SERVICE_FQDN}:443|dm-store-aat.service.core-compute-aat.internal)/documents
         NODE_TLS_REJECT_UNAUTHORIZED: 0
+        APPINSIGHTS_INSTRUMENTATIONKEY: ${APPINSIGHTS_INSTRUMENTATIONKEY}
       ingressHost: case-management-web-${SERVICE_FQDN}
       ingressIP: ${INGRESS_IP}
     idam-pr:

--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-resp-journey-roles-and-permissions-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-resp-journey-roles-and-permissions-nonprod.json
@@ -166,5 +166,54 @@
     "CaseEventID": "amendPetitionForRefusalSol",
     "UserRole": "[PETSOLICITOR]",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "UserRole": "[PETSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "UserRole": "[RESPSOLICITOR]",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "UserRole": "citizen",
+    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-roles-and-permissions-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-roles-and-permissions-nonprod.json
@@ -1,0 +1,13 @@
+[
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "UpdatePetSolContactDetails",
+    "Name": "Update contact details",
+    "Description": "Update contact details",
+    "DisplayOrder": 1,
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public"
+  }
+]

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-resp-journey-roles-and-permissions-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-resp-journey-roles-and-permissions-nonprod.json
@@ -2246,5 +2246,65 @@
     "PageLabel": "Upload the marriage certificate",
     "PageDisplayOrder": 1,
     "ShowSummaryChangeOption": "No"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "CaseFieldID": "PetitionerSolicitorName",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "OPTIONAL",
+    "PageID": "updatePetSolContactDetails",
+    "PageLabel": "Update contact details",
+    "PageDisplayOrder": 1,
+    "ShowSummaryChangeOption": "Yes"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "CaseFieldID": "PetitionerSolicitorPhone",
+    "PageFieldDisplayOrder": 2,
+    "DisplayContext": "OPTIONAL",
+    "PageID": "updatePetSolContactDetails",
+    "PageLabel": "Update contact details",
+    "PageDisplayOrder": 1,
+    "ShowSummaryChangeOption": "Yes"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "CaseFieldID": "PetitionerSolicitorEmail",
+    "PageFieldDisplayOrder": 3,
+    "DisplayContext": "MANDATORY",
+    "PageID": "updatePetSolContactDetails",
+    "PageLabel": "Update contact details",
+    "PageDisplayOrder": 1,
+    "ShowSummaryChangeOption": "Yes"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "CaseFieldID": "SolicitorAgreeToReceiveEmails",
+    "PageFieldDisplayOrder": 4,
+    "DisplayContext": "MANDATORY",
+    "PageID": "updatePetSolContactDetails",
+    "PageLabel": "Update contact details",
+    "PageDisplayOrder": 1,
+    "ShowSummaryChangeOption": "Yes"
+  },
+  {
+    "LiveFrom": "10/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "UpdatePetSolContactDetails",
+    "CaseFieldID": "DerivedPetitionerSolicitorAddr",
+    "PageFieldDisplayOrder": 5,
+    "DisplayContext": "MANDATORY",
+    "PageID": "updatePetSolContactDetails",
+    "PageLabel": "Update contact details",
+    "PageDisplayOrder": 1,
+    "ShowSummaryChangeOption": "Yes"
   }
 ]

--- a/test/unit/utils/dataProvider.js
+++ b/test/unit/utils/dataProvider.js
@@ -112,7 +112,7 @@ module.exports = {
         'CaseEvent-general-email-nonprod',
         'CaseEvent-general-referral-nonprod',
         'CaseEvent-share-a-case-nonprod',
-        'AuthorisationCaseEvent-resp-journey-roles-and-permissions-nonprod',
+        'CaseEvent-resp-journey-roles-and-permissions-nonprod',
         'CaseEvent-nonprod'
       ]),
     CaseEventToFields: getCaseEventToFieldsDefinitions([

--- a/test/unit/utils/dataProvider.js
+++ b/test/unit/utils/dataProvider.js
@@ -81,6 +81,7 @@ module.exports = {
         'AuthorisationCaseEvent-deemed-and-dispensed-nonprod',
         'AuthorisationCaseEvent-general-email-nonprod',
         'AuthorisationCaseEvent-general-referral-nonprod',
+        'AuthorisationCaseEvent-resp-journey-roles-and-permissions-nonprod',
         'AuthorisationCaseEvent-nonprod'
       ]
     ),
@@ -111,6 +112,7 @@ module.exports = {
         'CaseEvent-general-email-nonprod',
         'CaseEvent-general-referral-nonprod',
         'CaseEvent-share-a-case-nonprod',
+        'AuthorisationCaseEvent-resp-journey-roles-and-permissions-nonprod',
         'CaseEvent-nonprod'
       ]),
     CaseEventToFields: getCaseEventToFieldsDefinitions([


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6723

### Permissions ###

Event | [PETSOLICITOR] | [RESPSOLICITOR] | caseworker-beta | caseworker-admin | caseworker-la | citizen
-- | -- | -- | -- | -- | -- | --
UpdatePetSolContactDetails | **CRU** | R | R | R | R | R

Acceptance criteria
   
```
1. [PETSOLICITOR] is able to trigger a new event '_UpdatePetSolContactDetails_' (Update contact details) from any state. Permissions = CRU.
2. [RESPSOLICITOR] is are unable to trigger this event.
3. Permissions for [RESPSOLICITOR] , caseworker-beta, caseworker-admin, citizen and LA = R
4. A page is presented where the Petitioner solicitor can update the following fields:
    - 'PetitionerSolicitorName'
    - 'PetitionerSolicitorPhone'
    - 'PetitionerSolicitorEmail'
    - 'SolicitorAgreeToReceiveEmails'
    - 'DerivedPetitionerSolicitorAddr'
5. A check your answers page exists
6. When event is submitted there is no change to case state.
```