### PR TITLE
DIV-6779: extend pre conditions for general referral / alt services

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-resp-journey-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-resp-journey-nonprod.json
@@ -334,5 +334,40 @@
     "CaseEventID": "transferCaseFromCTSCAosDrafted",
     "UserRole": "citizen",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "confirmProcessServerService",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "confirmProcessServerService",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "confirmProcessServerService",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "confirmProcessServerService",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "confirmProcessServerService",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-resp-journey-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-resp-journey-nonprod.json
@@ -369,5 +369,33 @@
     "CaseEventID": "confirmProcessServerService",
     "UserRole": "caseworker-divorce-superuser",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "reissueFromAosDrafted",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "reissueFromAosDrafted",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "reissueFromAosDrafted",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "reissueFromAosDrafted",
+    "UserRole": "citizen",
+    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-resp-journey-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-resp-journey-nonprod.json
@@ -389,7 +389,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseEventID": "reissueFromAosDrafted",
     "UserRole": "caseworker-divorce-courtadmin_beta",
-    "CRUD": "R"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/03/2021",

--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-resp-journey-prod.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-resp-journey-prod.json
@@ -208,5 +208,40 @@
     "CaseEventID": "solicitorSubmitAOS",
     "UserRole": "[RESPSOLICITOR]",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "confirmProcessServerService",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "confirmProcessServerService",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "confirmProcessServerService",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "confirmProcessServerService",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "confirmProcessServerService",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -7493,41 +7493,6 @@
     "LiveFrom": "03/11/2020",
     "CaseTypeID": "DIVORCE",
     "CaseEventID": "confirmProcessServerService",
-    "UserRole": "caseworker-divorce-courtadmin",
-    "CRUD": "R"
-  },
-  {
-    "LiveFrom": "03/11/2020",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "confirmProcessServerService",
-    "UserRole": "caseworker-divorce-courtadmin_beta",
-    "CRUD": "CRU"
-  },
-  {
-    "LiveFrom": "03/11/2020",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "confirmProcessServerService",
-    "UserRole": "caseworker-divorce-courtadmin-la",
-    "CRUD": "R"
-  },
-  {
-    "LiveFrom": "03/11/2020",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "confirmProcessServerService",
-    "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "R"
-  },
-  {
-    "LiveFrom": "03/11/2020",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "confirmProcessServerService",
-    "UserRole": "caseworker-divorce-superuser",
-    "CRUD": "R"
-  },
-  {
-    "LiveFrom": "03/11/2020",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "confirmProcessServerService",
     "UserRole": "citizen",
     "CRUD": "R"
   },

--- a/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-nonprod.json
@@ -107,5 +107,18 @@
     "PostConditionState": "AosAwaiting",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/confirm-process-server-service",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "reissueFromAosDrafted",
+    "Name": "Reissue petition",
+    "Description": "Reissue petition",
+    "DisplayOrder": 2,
+    "PreConditionState(s)": "AosDrafted",
+    "PostConditionState": "AwaitingReissue",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/petition-issued?generateAosInvitation=true",
+    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-nonprod.json
@@ -95,5 +95,17 @@
     "PreConditionState(s)": "AosDrafted",
     "PostConditionState": "Issued",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "confirmProcessServerService",
+    "Name": "Confirm process service",
+    "Description": "Confirm process service",
+    "DisplayOrder": 32,
+    "PreConditionState(s)": "AwaitingProcessServerService;AosDrafted",
+    "PostConditionState": "AosAwaiting",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/confirm-process-server-service",
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-nonprod.json
@@ -118,7 +118,6 @@
     "PreConditionState(s)": "AosDrafted",
     "PostConditionState": "AwaitingReissue",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/petition-issued?generateAosInvitation=true",
-    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
     "SecurityClassification": "Public"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-prod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-prod.json
@@ -60,5 +60,17 @@
     "PreConditionState(s)": "GeneralConsiderationComplete;AosAwaiting;AosStarted;AosOverdue;Issued;AwaitingDocuments",
     "PostConditionState": "AwaitingProcessServerService",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "03/11/2020",
+    "CaseTypeID": "DIVORCE",
+    "ID": "confirmProcessServerService",
+    "Name": "Confirm process service",
+    "Description": "Confirm process service",
+    "DisplayOrder": 32,
+    "PreConditionState(s)": "AwaitingProcessServerService",
+    "PostConditionState": "AosAwaiting",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/confirm-process-server-service",
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent.json
@@ -2931,18 +2931,6 @@
     "ShowSummary": "Y"
   },
   {
-    "LiveFrom": "03/11/2020",
-    "CaseTypeID": "DIVORCE",
-    "ID": "confirmProcessServerService",
-    "Name": "Confirm process service",
-    "Description": "Confirm process service",
-    "DisplayOrder": 32,
-    "PreConditionState(s)": "AwaitingProcessServerService",
-    "PostConditionState": "AosAwaiting",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/confirm-process-server-service",
-    "SecurityClassification": "Public"
-  },
-  {
     "LiveFrom": "30/10/2020",
     "CaseTypeID": "DIVORCE",
     "ID": "serveByAlternativeMethod",


### PR DESCRIPTION

### JIRA link (if applicable) ###



### Change description ###
**Acceptance criteria**

1.   General Referral. The event 'General referral' can be triggered from the state 'AOSdrafted'. Note: Because 'General referral is available from any state, this will happen automatically.
2.     Caseworker-divorce-beta is given CRU access to the 'AosDrafted' state
3.     Serve by process server. The 'serveByProcessServer' pre-condition states extended to include 'AosDrafted'
4.     Confirm process server service. The 'confirmProcessServerService' event, pre-condition states extended to include 'AOSdrafted'
5.     A new Reissue event. The new 'Reissue' from the state 'AOS drafted'



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
