### PR TITLE
RPET-694: Update Sol text for Brexit

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-sol-brexit-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-sol-brexit-nonprod.json
@@ -1,0 +1,86 @@
+[
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "D8JurisdictionConnectionNewPolicy",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "NewLegalConnectionPolicy",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "D8JurisdictionConnectionNewPolicy",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "NewLegalConnectionPolicy",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "D8JurisdictionConnectionNewPolicy",
+    "UserRole": "citizen",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "NewLegalConnectionPolicy",
+    "UserRole": "citizen",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "D8JurisdictionConnectionNewPolicy",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "NewLegalConnectionPolicy",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "D8JurisdictionConnectionNewPolicy",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "NewLegalConnectionPolicy",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "D8JurisdictionConnectionNewPolicy",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "NewLegalConnectionPolicy",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "CRU"
+  }
+]

--- a/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-sol-brexit-prod.json
+++ b/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField-sol-brexit-prod.json
@@ -1,0 +1,9 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "labelResidualJurisdictionPara-1",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "CRU"
+  }
+]

--- a/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -3985,13 +3985,6 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
-    "CaseFieldID": "labelResidualJurisdictionPara-1",
-    "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "CRU"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
     "CaseFieldID": "labelResidualJurisdictionPara-2",
     "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "CRU"

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-resp-journey-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-resp-journey-nonprod.json
@@ -257,30 +257,6 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseEventID": "solicitorCreate",
-    "CaseFieldID": "D8JurisdictionConnection",
-    "PageFieldDisplayOrder": 4,
-    "DisplayContext": "MANDATORY",
-    "PageID": "SolJurisdiction",
-    "PageLabel": "Jurisdiction",
-    "PageDisplayOrder": 6,
-    "ShowSummaryChangeOption": "Yes"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "solicitorCreate",
-    "CaseFieldID": "labelResidualJurisdictionPara-1",
-    "PageFieldDisplayOrder": 5,
-    "DisplayContext": "READONLY",
-    "PageID": "SolJurisdiction",
-    "PageLabel": "Jurisdiction",
-    "PageDisplayOrder": 6,
-    "ShowSummaryChangeOption": "No"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "solicitorCreate",
     "CaseFieldID": "LabelSolReasonForDivorcePara-1",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "READONLY",
@@ -1381,30 +1357,6 @@
     "PageLabel": "Jurisdiction",
     "PageDisplayOrder": 6,
     "FieldShowCondition": "D8MarriageIsSameSexCouple=\"Yes\"",
-    "ShowSummaryChangeOption": "No"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "solicitorUpdate",
-    "CaseFieldID": "D8JurisdictionConnection",
-    "PageFieldDisplayOrder": 4,
-    "DisplayContext": "MANDATORY",
-    "PageID": "SolJurisdictionUpdate",
-    "PageLabel": "Jurisdiction",
-    "PageDisplayOrder": 6,
-    "ShowSummaryChangeOption": "Yes"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "solicitorUpdate",
-    "CaseFieldID": "labelResidualJurisdictionPara-1",
-    "PageFieldDisplayOrder": 5,
-    "DisplayContext": "READONLY",
-    "PageID": "SolJurisdictionUpdate",
-    "PageLabel": "Jurisdiction",
-    "PageDisplayOrder": 6,
     "ShowSummaryChangeOption": "No"
   },
   {

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-resp-journey-prod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-resp-journey-prod.json
@@ -139,30 +139,6 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseEventID": "solicitorCreate",
-    "CaseFieldID": "D8JurisdictionConnection",
-    "PageFieldDisplayOrder": 4,
-    "DisplayContext": "MANDATORY",
-    "PageID": "SolJurisdiction",
-    "PageLabel": "Jurisdiction",
-    "PageDisplayOrder": 5,
-    "ShowSummaryChangeOption": "Yes"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "solicitorCreate",
-    "CaseFieldID": "labelResidualJurisdictionPara-1",
-    "PageFieldDisplayOrder": 5,
-    "DisplayContext": "READONLY",
-    "PageID": "SolJurisdiction",
-    "PageLabel": "Jurisdiction",
-    "PageDisplayOrder": 5,
-    "ShowSummaryChangeOption": "No"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "solicitorCreate",
     "CaseFieldID": "LabelSolReasonForDivorcePara-1",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "READONLY",
@@ -1145,30 +1121,6 @@
     "PageLabel": "Jurisdiction",
     "PageDisplayOrder": 5,
     "FieldShowCondition": "D8MarriageIsSameSexCouple=\"Yes\"",
-    "ShowSummaryChangeOption": "No"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "solicitorUpdate",
-    "CaseFieldID": "D8JurisdictionConnection",
-    "PageFieldDisplayOrder": 4,
-    "DisplayContext": "MANDATORY",
-    "PageID": "SolJurisdictionUpdate",
-    "PageLabel": "Jurisdiction",
-    "PageDisplayOrder": 5,
-    "ShowSummaryChangeOption": "Yes"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "CaseEventID": "solicitorUpdate",
-    "CaseFieldID": "labelResidualJurisdictionPara-1",
-    "PageFieldDisplayOrder": 5,
-    "DisplayContext": "READONLY",
-    "PageID": "SolJurisdictionUpdate",
-    "PageLabel": "Jurisdiction",
-    "PageDisplayOrder": 5,
     "ShowSummaryChangeOption": "No"
   },
   {

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-sol-brexit-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-sol-brexit-nonprod.json
@@ -1,0 +1,52 @@
+[
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorCreate",
+    "CaseFieldID": "NewLegalConnectionPolicy",
+    "PageFieldDisplayOrder": 4,
+    "DisplayContext": "OPTIONAL",
+    "PageID": "SolJurisdiction",
+    "PageLabel": "Jurisdiction",
+    "PageDisplayOrder": 6,
+    "FieldShowCondition": "D8PetitionerPhoneNumber=\"NEVERSHOW\"",
+    "ShowSummaryChangeOption": "No"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorCreate",
+    "CaseFieldID": "D8JurisdictionConnectionNewPolicy",
+    "PageFieldDisplayOrder": 5,
+    "DisplayContext": "MANDATORY",
+    "PageID": "SolJurisdiction",
+    "PageLabel": "Jurisdiction",
+    "PageDisplayOrder": 6,
+    "ShowSummaryChangeOption": "Yes"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorUpdate",
+    "CaseFieldID": "NewLegalConnectionPolicy",
+    "PageFieldDisplayOrder": 4,
+    "DisplayContext": "OPTIONAL",
+    "PageID": "SolJurisdictionUpdate",
+    "PageLabel": "Jurisdiction",
+    "PageDisplayOrder": 6,
+    "FieldShowCondition": "D8PetitionerPhoneNumber=\"NEVERSHOW\"",
+    "ShowSummaryChangeOption": "No"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorUpdate",
+    "CaseFieldID": "D8JurisdictionConnectionNewPolicy",
+    "PageFieldDisplayOrder": 5,
+    "DisplayContext": "MANDATORY",
+    "PageID": "SolJurisdictionUpdate",
+    "PageLabel": "Jurisdiction",
+    "PageDisplayOrder": 6,
+    "ShowSummaryChangeOption": "Yes"
+  }
+]

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-sol-brexit-prod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-sol-brexit-prod.json
@@ -1,0 +1,50 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorCreate",
+    "CaseFieldID": "D8JurisdictionConnection",
+    "PageFieldDisplayOrder": 4,
+    "DisplayContext": "MANDATORY",
+    "PageID": "SolJurisdiction",
+    "PageLabel": "Jurisdiction",
+    "PageDisplayOrder": 5,
+    "ShowSummaryChangeOption": "Yes"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorCreate",
+    "CaseFieldID": "labelResidualJurisdictionPara-1",
+    "PageFieldDisplayOrder": 5,
+    "DisplayContext": "READONLY",
+    "PageID": "SolJurisdiction",
+    "PageLabel": "Jurisdiction",
+    "PageDisplayOrder": 5,
+    "ShowSummaryChangeOption": "No"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorUpdate",
+    "CaseFieldID": "D8JurisdictionConnection",
+    "PageFieldDisplayOrder": 4,
+    "DisplayContext": "MANDATORY",
+    "PageID": "SolJurisdictionUpdate",
+    "PageLabel": "Jurisdiction",
+    "PageDisplayOrder": 5,
+    "ShowSummaryChangeOption": "Yes"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorUpdate",
+    "CaseFieldID": "labelResidualJurisdictionPara-1",
+    "PageFieldDisplayOrder": 5,
+    "DisplayContext": "READONLY",
+    "PageID": "SolJurisdictionUpdate",
+    "PageLabel": "Jurisdiction",
+    "PageDisplayOrder": 5,
+    "ShowSummaryChangeOption": "No"
+  }
+]

--- a/definitions/divorce/json/CaseField/CaseField-sol-brexit-nonprod.json
+++ b/definitions/divorce/json/CaseField/CaseField-sol-brexit-nonprod.json
@@ -1,0 +1,20 @@
+[
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "NewLegalConnectionPolicy",
+    "Label": "Determine which legal connection wording to use.",
+    "FieldType": "YesOrNo",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "D8JurisdictionConnectionNewPolicy",
+    "Label": "Legal connections",
+    "HintText": "Tick all the reasons that apply:",
+    "FieldType": "MultiSelectList",
+    "FieldTypeParameter": "jurisdictionConnectionsEnumNewPolicy",
+    "SecurityClassification": "Public"
+  }
+]

--- a/definitions/divorce/json/CaseField/CaseField-sol-brexit-prod.json
+++ b/definitions/divorce/json/CaseField/CaseField-sol-brexit-prod.json
@@ -1,0 +1,10 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "ID": "labelResidualJurisdictionPara-1",
+    "Label": "## Residual Jurisdiction\r\n\r\nThe court may have residual jurisdiction if;\r\n\r\nnone of the other connections applies in relation to England and Wales;\r\n\r\neither the petitioner or the respondent is domiciled in England or Wales; and \r\n\r\nneither the petitioner nor the respondent is able to apply for a divorce in another member state of the EU on the basis of any of the other connections.\r\n\r\nIn addition, in the case of a same-sex marriage, the court may have residual jurisdiction if the following apply:\r\n\r\n- The petitioner and the respondent married each other in England or Wales; and\r\n- Neither the petitioner nor the respondent is able to apply for a divorce in any other country; and\r\n- It would be in the interests of justice for the court to consider the application (this may apply if, for example, the petitioner's or respondent’s home country doesn’t allow divorce between same-sex couples).",
+    "FieldType": "Label",
+    "SecurityClassification": "Public"
+  }
+]

--- a/definitions/divorce/json/CaseField/CaseField.json
+++ b/definitions/divorce/json/CaseField/CaseField.json
@@ -1981,14 +1981,6 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
-    "ID": "labelResidualJurisdictionPara-1",
-    "Label": "## Residual Jurisdiction\r\n\r\nThe court may have residual jurisdiction if;\r\n\r\nnone of the other connections applies in relation to England and Wales;\r\n\r\neither the petitioner or the respondent is domiciled in England or Wales; and \r\n\r\nneither the petitioner nor the respondent is able to apply for a divorce in another member state of the EU on the basis of any of the other connections.\r\n\r\nIn addition, in the case of a same-sex marriage, the court may have residual jurisdiction if the following apply:\r\n\r\n- The petitioner and the respondent married each other in England or Wales; and\r\n- Neither the petitioner nor the respondent is able to apply for a divorce in any other country; and\r\n- It would be in the interests of justice for the court to consider the application (this may apply if, for example, the petitioner's or respondent’s home country doesn’t allow divorce between same-sex couples).",
-    "FieldType": "Label",
-    "SecurityClassification": "Public"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
     "ID": "labelResidualJurisdictionPara-2",
     "Label": "Usually, to be eligible for residual jurisdiction, the petitioner and/or the respondent must be domiciled in England or Wales, ",
     "FieldType": "Label",

--- a/definitions/divorce/json/CaseTypeTab/CaseTypeTab-sol-brexit-nonprod.json
+++ b/definitions/divorce/json/CaseTypeTab/CaseTypeTab-sol-brexit-nonprod.json
@@ -1,0 +1,35 @@
+[
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "petitionDetails",
+    "TabLabel": "Petition",
+    "TabDisplayOrder": 2,
+    "CaseFieldID": "D8JurisdictionConnection",
+    "TabFieldDisplayOrder": 77,
+    "FieldShowCondition": "NewLegalConnectionPolicy!=\"Yes\""
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "petitionDetails",
+    "TabLabel": "Petition",
+    "TabDisplayOrder": 2,
+    "CaseFieldID": "D8JurisdictionConnectionNewPolicy",
+    "TabFieldDisplayOrder": 78,
+    "FieldShowCondition": "NewLegalConnectionPolicy=\"Yes\""
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "petitionDetails",
+    "TabLabel": "Petition",
+    "TabDisplayOrder": 2,
+    "CaseFieldID": "NewLegalConnectionPolicy",
+    "TabFieldDisplayOrder": 121,
+    "FieldShowCondition": "NewLegalConnectionPolicy=\"NEVERSHOW\""
+  }
+]

--- a/definitions/divorce/json/CaseTypeTab/CaseTypeTab-sol-brexit-prod.json
+++ b/definitions/divorce/json/CaseTypeTab/CaseTypeTab-sol-brexit-prod.json
@@ -1,0 +1,12 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "petitionDetails",
+    "TabLabel": "Petition",
+    "TabDisplayOrder": 2,
+    "CaseFieldID": "D8JurisdictionConnection",
+    "TabFieldDisplayOrder": 77
+  }
+]

--- a/definitions/divorce/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/divorce/json/CaseTypeTab/CaseTypeTab.json
@@ -472,7 +472,7 @@
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
     "CaseFieldID": "D8RespondentSolicitorEmail",
-    "TabFieldDisplayOrder": 46
+    "TabFieldDisplayOrder": 45
   },
   {
     "LiveFrom": "01/01/2017",
@@ -808,27 +808,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8JurisdictionConnection",
-    "TabFieldDisplayOrder": 77
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "Channel": "CaseWorker",
-    "TabID": "petitionDetails",
-    "TabLabel": "Petition",
-    "TabDisplayOrder": 2,
     "CaseFieldID": "D8DerivedLivingArrangementsLastLivedAddr",
-    "TabFieldDisplayOrder": 78
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "Channel": "CaseWorker",
-    "TabID": "petitionDetails",
-    "TabLabel": "Petition",
-    "TabDisplayOrder": 2,
-    "CaseFieldID": "labelOtherProceedingsPetitioner",
     "TabFieldDisplayOrder": 79
   },
   {
@@ -838,8 +818,18 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8LegalProceedings",
+    "CaseFieldID": "labelOtherProceedingsPetitioner",
     "TabFieldDisplayOrder": 80
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "petitionDetails",
+    "TabLabel": "Petition",
+    "TabDisplayOrder": 2,
+    "CaseFieldID": "D8LegalProceedings",
+    "TabFieldDisplayOrder": 81
   },
   {
     "LiveFrom": "18/12/2019",
@@ -849,16 +839,6 @@
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
     "CaseFieldID": "D8LegalProceedingsDetailsCaseNumber",
-    "TabFieldDisplayOrder": 81
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "Channel": "CaseWorker",
-    "TabID": "petitionDetails",
-    "TabLabel": "Petition",
-    "TabDisplayOrder": 2,
-    "CaseFieldID": "D8LegalProceedingsRelated",
     "TabFieldDisplayOrder": 82
   },
   {
@@ -868,7 +848,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8LegalProceedingsDetails",
+    "CaseFieldID": "D8LegalProceedingsRelated",
     "TabFieldDisplayOrder": 83
   },
   {
@@ -878,7 +858,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8FinancialOrder",
+    "CaseFieldID": "D8LegalProceedingsDetails",
     "TabFieldDisplayOrder": 84
   },
   {
@@ -888,7 +868,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8FinancialOrderFor",
+    "CaseFieldID": "D8FinancialOrder",
     "TabFieldDisplayOrder": 85
   },
   {
@@ -898,7 +878,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8DivorceCostsClaim",
+    "CaseFieldID": "D8FinancialOrderFor",
     "TabFieldDisplayOrder": 86
   },
   {
@@ -908,7 +888,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8DivorceClaimFrom",
+    "CaseFieldID": "D8DivorceCostsClaim",
     "TabFieldDisplayOrder": 87
   },
   {
@@ -918,7 +898,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8StatementOfTruth",
+    "CaseFieldID": "D8DivorceClaimFrom",
     "TabFieldDisplayOrder": 88
   },
   {
@@ -928,7 +908,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "solSignStatementofTruth",
+    "CaseFieldID": "D8StatementOfTruth",
     "TabFieldDisplayOrder": 89
   },
   {
@@ -938,7 +918,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "SolStatementOfReconciliationCertify",
+    "CaseFieldID": "solSignStatementofTruth",
     "TabFieldDisplayOrder": 90
   },
   {
@@ -948,7 +928,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "SolStatementOfReconciliationDiscussed",
+    "CaseFieldID": "SolStatementOfReconciliationCertify",
     "TabFieldDisplayOrder": 91
   },
   {
@@ -958,7 +938,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "StatementOfReconciliationComments",
+    "CaseFieldID": "SolStatementOfReconciliationDiscussed",
     "TabFieldDisplayOrder": 92
   },
   {
@@ -968,7 +948,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "SolUrgentCase",
+    "CaseFieldID": "StatementOfReconciliationComments",
     "TabFieldDisplayOrder": 93
   },
   {
@@ -978,8 +958,18 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
+    "CaseFieldID": "SolUrgentCase",
+    "TabFieldDisplayOrder": 94
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "petitionDetails",
+    "TabLabel": "Petition",
+    "TabDisplayOrder": 2,
     "CaseFieldID": "SolUrgentCaseSupportingInformation",
-    "TabFieldDisplayOrder": 94,
+    "TabFieldDisplayOrder": 95,
     "FieldShowCondition": "SolUrgentCase=\"Yes\""
   },
   {
@@ -990,16 +980,6 @@
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
     "CaseFieldID": "SolStatementOfReconciliationName",
-    "TabFieldDisplayOrder": 95
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "Channel": "CaseWorker",
-    "TabID": "petitionDetails",
-    "TabLabel": "Petition",
-    "TabDisplayOrder": 2,
-    "CaseFieldID": "SolStatementOfReconciliationFirm",
     "TabFieldDisplayOrder": 96
   },
   {
@@ -1009,7 +989,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8MarriagePetitionerName",
+    "CaseFieldID": "SolStatementOfReconciliationFirm",
     "TabFieldDisplayOrder": 97
   },
   {
@@ -1019,7 +999,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8MarriageDate",
+    "CaseFieldID": "D8MarriagePetitionerName",
     "TabFieldDisplayOrder": 98
   },
   {
@@ -1029,7 +1009,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8MarriedInUk",
+    "CaseFieldID": "D8MarriageDate",
     "TabFieldDisplayOrder": 99
   },
   {
@@ -1039,7 +1019,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8MarriagePlaceOfMarriage",
+    "CaseFieldID": "D8MarriedInUk",
     "TabFieldDisplayOrder": 100
   },
   {
@@ -1049,7 +1029,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8CountryName",
+    "CaseFieldID": "D8MarriagePlaceOfMarriage",
     "TabFieldDisplayOrder": 101
   },
   {
@@ -1059,7 +1039,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8DivorceWho",
+    "CaseFieldID": "D8CountryName",
     "TabFieldDisplayOrder": 102
   },
   {
@@ -1069,7 +1049,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8MarriageIsSameSexCouple",
+    "CaseFieldID": "D8DivorceWho",
     "TabFieldDisplayOrder": 103
   },
   {
@@ -1079,7 +1059,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "D8CertificateInEnglish",
+    "CaseFieldID": "D8MarriageIsSameSexCouple",
     "TabFieldDisplayOrder": 104
   },
   {
@@ -1089,8 +1069,18 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
+    "CaseFieldID": "D8CertificateInEnglish",
+    "TabFieldDisplayOrder": 105
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "petitionDetails",
+    "TabLabel": "Petition",
+    "TabDisplayOrder": 2,
     "CaseFieldID": "Label-SolicitorPersonalService",
-    "TabFieldDisplayOrder": 105,
+    "TabFieldDisplayOrder": 106,
     "FieldShowCondition": "SolServiceMethod=\"personalService\""
   },
   {
@@ -1101,7 +1091,7 @@
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
     "CaseFieldID": "SolServiceMethod",
-    "TabFieldDisplayOrder": 106,
+    "TabFieldDisplayOrder": 107,
     "FieldShowCondition": "SolServiceMethod=\"*\""
   },
   {
@@ -1112,16 +1102,6 @@
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
     "CaseFieldID": "DateOfService",
-    "TabFieldDisplayOrder": 107
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "Channel": "CaseWorker",
-    "TabID": "petitionDetails",
-    "TabLabel": "Petition",
-    "TabDisplayOrder": 2,
-    "CaseFieldID": "SendAosPackToResp",
     "TabFieldDisplayOrder": 108
   },
   {
@@ -1131,7 +1111,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "DocumentsServed",
+    "CaseFieldID": "SendAosPackToResp",
     "TabFieldDisplayOrder": 109
   },
   {
@@ -1141,7 +1121,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "OnWhomServed",
+    "CaseFieldID": "DocumentsServed",
     "TabFieldDisplayOrder": 110
   },
   {
@@ -1151,7 +1131,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "HowServed",
+    "CaseFieldID": "OnWhomServed",
     "TabFieldDisplayOrder": 111
   },
   {
@@ -1161,8 +1141,18 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
+    "CaseFieldID": "HowServed",
+    "TabFieldDisplayOrder": 112
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "petitionDetails",
+    "TabLabel": "Petition",
+    "TabDisplayOrder": 2,
     "CaseFieldID": "ServiceDetails",
-    "TabFieldDisplayOrder": 112,
+    "TabFieldDisplayOrder": 113,
     "FieldShowCondition": "HowServed=\"personalHanding\" OR HowServed=\"other\""
   },
   {
@@ -1173,16 +1163,6 @@
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
     "CaseFieldID": "ServiceAddress",
-    "TabFieldDisplayOrder": 113
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "Channel": "CaseWorker",
-    "TabID": "petitionDetails",
-    "TabLabel": "Petition",
-    "TabDisplayOrder": 2,
-    "CaseFieldID": "BeingThe",
     "TabFieldDisplayOrder": 114
   },
   {
@@ -1192,7 +1172,7 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
-    "CaseFieldID": "ServiceLocation",
+    "CaseFieldID": "BeingThe",
     "TabFieldDisplayOrder": 115
   },
   {
@@ -1202,8 +1182,18 @@
     "TabID": "petitionDetails",
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
+    "CaseFieldID": "ServiceLocation",
+    "TabFieldDisplayOrder": 116
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "petitionDetails",
+    "TabLabel": "Petition",
+    "TabDisplayOrder": 2,
     "CaseFieldID": "OtherServiceLocation",
-    "TabFieldDisplayOrder": 116,
+    "TabFieldDisplayOrder": 117,
     "FieldShowCondition": "BeingThe=\"Other\""
   },
   {
@@ -1214,7 +1204,7 @@
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
     "CaseFieldID": "ServiceSOTLabel",
-    "TabFieldDisplayOrder": 117
+    "TabFieldDisplayOrder": 118
   },
   {
     "LiveFrom": "01/01/2017",
@@ -1224,7 +1214,7 @@
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
     "CaseFieldID": "ServiceSOTName",
-    "TabFieldDisplayOrder": 118
+    "TabFieldDisplayOrder": 119
   },
   {
     "LiveFrom": "14/09/2020",
@@ -1234,7 +1224,7 @@
     "TabLabel": "Petition",
     "TabDisplayOrder": 2,
     "CaseFieldID": "PetitionerPcqId",
-    "TabFieldDisplayOrder": 119
+    "TabFieldDisplayOrder": 120
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/divorce/json/ComplexTypes/ComplexTypes.json
+++ b/definitions/divorce/json/ComplexTypes/ComplexTypes.json
@@ -310,6 +310,22 @@
   },
   {
     "LiveFrom": "01/01/2017",
+    "ID": "Connections",
+    "ListElementCode": "H",
+    "FieldType": "Text",
+    "ElementLabel": "Connection H",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "Connections",
+    "ListElementCode": "I",
+    "FieldType": "Text",
+    "ElementLabel": "Connection I",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
     "ID": "CaseNote",
     "ListElementCode": "Author",
     "FieldType": "Text",

--- a/definitions/divorce/json/FixedLists/FixedLists-sol-brexit-nonprod.json
+++ b/definitions/divorce/json/FixedLists/FixedLists-sol-brexit-nonprod.json
@@ -1,0 +1,68 @@
+[
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnum",
+    "ListElementCode": "H",
+    "ListElement": "The Petitioner is domiciled in England and Wales"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnum",
+    "ListElementCode": "I",
+    "ListElement": "The Respondent is domiciled in England and Wales"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnumNewPolicy",
+    "ListElementCode": "A",
+    "ListElement": "The Petitioner and the Respondent are habitually resident in England and Wales"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnumNewPolicy",
+    "ListElementCode": "B",
+    "ListElement": "The Petitioner and Respondent were last habitually resident in England and Wales and one of them still resides there"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnumNewPolicy",
+    "ListElementCode": "C",
+    "ListElement": "The Respondent is habitually resident in England and Wales"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnumNewPolicy",
+    "ListElementCode": "D",
+    "ListElement": "The Petitioner is habitually resident in England and Wales and has resided there for at least a year immediately prior to the presentation of the petition"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnumNewPolicy",
+    "ListElementCode": "E",
+    "ListElement": "The Petitioner is domiciled and habitually resident in England and Wales and has resided there for at least six months immediately prior to the petition"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnumNewPolicy",
+    "ListElementCode": "F",
+    "ListElement": "The Petitioner and Respondent are both domiciled in England and Wales"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnumNewPolicy",
+    "ListElementCode": "G",
+    "ListElement": "The courts of England and Wales have residual jurisdiction (same sex married couple)"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnumNewPolicy",
+    "ListElementCode": "H",
+    "ListElement": "The Petitioner is domiciled in England and Wales"
+  },
+  {
+    "LiveFrom": "15/02/2021",
+    "ID": "jurisdictionConnectionsEnumNewPolicy",
+    "ListElementCode": "I",
+    "ListElement": "The Respondent is domiciled in England and Wales"
+  }
+]


### PR DESCRIPTION
+ Duplicate D8JurisdictionConnection and called it D8JurisdictionConnectionNewPolicy to change the wording for new brexit laws
+ Remove D8JurisdictionConnection from SolicitorCreate and SolicitorUpdate Events so the new fixed list is used
+ Create NewLegalConnectionPolicy that's automatically set to Yes on Create/Update submit callback events on div-cos and hide it from UI so it can't be seen
+ Use NewLegalConnectionPolicy to determine which fixed list policy to use in the case tab section on CCD
+ Remove labelResidualJurisdictionPara-1 because it's no longer valid/needed
+ Remove labelResidualJurisdictionPara-1 from non-prod files
+ Fix field display order
+ Remove labelResidualJurisdictionPara-1 from resp-journey files

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
