### PR TITLE
DIV-6778: Extend respondent solicitor AOS events pre-states to include Bailiff journey states

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-bailiff-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-bailiff-nonprod.json
@@ -145,5 +145,26 @@
     "CaseStateID": "IssuedToBailiff",
     "UserRole": "caseworker-divorce-courtadmin-la",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "02/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AwaitingBailiffReferral",
+    "UserRole": "[RESPSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "02/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AwaitingBailiffService",
+    "UserRole": "[RESPSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "02/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "IssuedToBailiff",
+    "UserRole": "[RESPSOLICITOR]",
+    "CRUD": "CRU"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-nonprod.json
@@ -69,5 +69,22 @@
     "SecurityClassification": "Public",
     "ShowSummary": "Y",
     "EndButtonLabel": "Save Updated AOS Response"
+  },
+  {
+    "LiveFrom": "02/01/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "solicitorSubmitAOS",
+    "Name": "Submit AoS",
+    "Description": "Submit Acknowledgement of Service",
+    "DisplayOrder": 2,
+    "PreConditionState(s)": "AosDrafted;AwaitingBailiffReferral;AwaitingBailiffService;IssuedToBailiff",
+    "PostConditionState": "AosPreSubmit",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/aos-received",
+    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/aos-submitted",
+    "RetriesTimeoutURLSubmittedEvent": "120,120",
+    "SecurityClassification": "Public",
+    "ShowSummary": "Y",
+    "EndButtonLabel": "Submit AOS Response"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-nonprod.json
@@ -39,5 +39,20 @@
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/issue-bailiff-pack",
     "SecurityClassification": "Public",
     "ShowSummary": "Y"
+  },
+  {
+    "LiveFrom": "02/01/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "solicitorDraftAOS",
+    "Name": "Draft AoS",
+    "Description": "Draft Acknowledgement of Service",
+    "DisplayOrder": 1,
+    "PreConditionState(s)": "AosAwaitingSol;AosAwaiting;AwaitingBailiffReferral;AwaitingBailiffService;IssuedToBailiff",
+    "PostConditionState": "AosDrafted",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition",
+    "RetriesTimeoutAboutToStartEvent": "120,120",
+    "SecurityClassification": "Public",
+    "ShowSummary": "Y",
+    "EndButtonLabel": "Save AOS Response"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-nonprod.json
@@ -54,5 +54,20 @@
     "SecurityClassification": "Public",
     "ShowSummary": "Y",
     "EndButtonLabel": "Save AOS Response"
+  },
+  {
+    "LiveFrom": "02/01/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "solicitorUpdateAOS",
+    "Name": "Update AoS",
+    "Description": "Update Acknowledgement of Service",
+    "DisplayOrder": 1,
+    "PreConditionState(s)": "AosDrafted;AwaitingBailiffReferral;AwaitingBailiffService;IssuedToBailiff",
+    "PostConditionState": "AosDrafted",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition",
+    "RetriesTimeoutAboutToStartEvent": "120,120",
+    "SecurityClassification": "Public",
+    "ShowSummary": "Y",
+    "EndButtonLabel": "Save Updated AOS Response"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-prod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-prod.json
@@ -42,5 +42,22 @@
     "SecurityClassification": "Public",
     "ShowSummary": "Y",
     "EndButtonLabel": "Save Updated AOS Response"
+  },
+  {
+    "LiveFrom": "18/07/2019",
+    "CaseTypeID": "DIVORCE",
+    "ID": "solicitorSubmitAOS",
+    "Name": "Submit AoS",
+    "Description": "Submit Acknowledgement of Service",
+    "DisplayOrder": 2,
+    "PreConditionState(s)": "AosDrafted",
+    "PostConditionState": "AosPreSubmit",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/aos-received",
+    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/aos-submitted",
+    "RetriesTimeoutURLSubmittedEvent": "120,120",
+    "SecurityClassification": "Public",
+    "ShowSummary": "Y",
+    "EndButtonLabel": "Submit AOS Response"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-prod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-prod.json
@@ -27,5 +27,20 @@
     "SecurityClassification": "Public",
     "ShowSummary": "Y",
     "EndButtonLabel": "Save AOS Response"
+  },
+  {
+    "LiveFrom": "18/07/2019",
+    "CaseTypeID": "DIVORCE",
+    "ID": "solicitorUpdateAOS",
+    "Name": "Update AoS",
+    "Description": "Update Acknowledgement of Service",
+    "DisplayOrder": 1,
+    "PreConditionState(s)": "AosDrafted",
+    "PostConditionState": "AosDrafted",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition",
+    "RetriesTimeoutAboutToStartEvent": "120,120",
+    "SecurityClassification": "Public",
+    "ShowSummary": "Y",
+    "EndButtonLabel": "Save Updated AOS Response"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-prod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-prod.json
@@ -12,5 +12,20 @@
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/confirm-service-payment",
     "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "18/07/2019",
+    "CaseTypeID": "DIVORCE",
+    "ID": "solicitorDraftAOS",
+    "Name": "Draft AoS",
+    "Description": "Draft Acknowledgement of Service",
+    "DisplayOrder": 1,
+    "PreConditionState(s)": "AosAwaitingSol;AosAwaiting",
+    "PostConditionState": "AosDrafted",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition",
+    "RetriesTimeoutAboutToStartEvent": "120,120",
+    "SecurityClassification": "Public",
+    "ShowSummary": "Y",
+    "EndButtonLabel": "Save AOS Response"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent.json
@@ -2180,21 +2180,6 @@
   {
     "LiveFrom": "18/07/2019",
     "CaseTypeID": "DIVORCE",
-    "ID": "solicitorDraftAOS",
-    "Name": "Draft AoS",
-    "Description": "Draft Acknowledgement of Service",
-    "DisplayOrder": 1,
-    "PreConditionState(s)": "AosAwaitingSol;AosAwaiting",
-    "PostConditionState": "AosDrafted",
-    "CallBackURLAboutToStartEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition",
-    "RetriesTimeoutAboutToStartEvent": "120,120",
-    "SecurityClassification": "Public",
-    "ShowSummary": "Y",
-    "EndButtonLabel": "Save AOS Response"
-  },
-  {
-    "LiveFrom": "18/07/2019",
-    "CaseTypeID": "DIVORCE",
     "ID": "solicitorUpdateAOS",
     "Name": "Update AoS",
     "Description": "Update Acknowledgement of Service",

--- a/definitions/divorce/json/CaseEvent/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent.json
@@ -2178,23 +2178,6 @@
     "ShowSummary": "Y"
   },
   {
-    "LiveFrom": "18/07/2019",
-    "CaseTypeID": "DIVORCE",
-    "ID": "solicitorSubmitAOS",
-    "Name": "Submit AoS",
-    "Description": "Submit Acknowledgement of Service",
-    "DisplayOrder": 2,
-    "PreConditionState(s)": "AosDrafted",
-    "PostConditionState": "AosPreSubmit",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/aos-received",
-    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
-    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/aos-submitted",
-    "RetriesTimeoutURLSubmittedEvent": "120,120",
-    "SecurityClassification": "Public",
-    "ShowSummary": "Y",
-    "EndButtonLabel": "Submit AOS Response"
-  },
-  {
     "LiveFrom": "12/08/2019",
     "CaseTypeID": "DIVORCE",
     "ID": "revertAosSubmit",

--- a/definitions/divorce/json/CaseEvent/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent.json
@@ -2180,21 +2180,6 @@
   {
     "LiveFrom": "18/07/2019",
     "CaseTypeID": "DIVORCE",
-    "ID": "solicitorUpdateAOS",
-    "Name": "Update AoS",
-    "Description": "Update Acknowledgement of Service",
-    "DisplayOrder": 1,
-    "PreConditionState(s)": "AosDrafted",
-    "PostConditionState": "AosDrafted",
-    "CallBackURLAboutToStartEvent": "${CCD_DEF_COS_URL}/sol-dn-review-petition",
-    "RetriesTimeoutAboutToStartEvent": "120,120",
-    "SecurityClassification": "Public",
-    "ShowSummary": "Y",
-    "EndButtonLabel": "Save Updated AOS Response"
-  },
-  {
-    "LiveFrom": "18/07/2019",
-    "CaseTypeID": "DIVORCE",
     "ID": "solicitorSubmitAOS",
     "Name": "Submit AoS",
     "Description": "Submit Acknowledgement of Service",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DIV-6778


### Change description ###

Acceptance criteria

    Draft AOS. The event 'solicitorDraftAOS' pre-state conditions to be extended to include 'AwaitingBailiffReferral' 'AwaitingBailiffService', 'IssuedToBailiff', (no change to post-state: event goes to 'solicitorDraftAOS') (DEV NOTE: Current "PostConditionState" for  "solicitorDraftAOS is "AosDrafted")
    Update AOS. The event 'solicitorUpdateAOS' pre-state conditions are extended to include 'AwaitingBailiffReferral' 'AwaitingBailiffService', 'IssuedToBailiff'. (no change to post state i.e. goes to 'AOSdrafted')
    Submit AOS. The event 'solicitorSubmitAOS' pre-state conditions to be extended to include 'AwaitingBailiffReferral' 'AwaitingBailiffService', 'IssuedToBailiff', (no change to post-state logic)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
