### PR TITLE
DIV-6762: updated 'issueAosFromReissue.CallBackURLSubmittedEvent'

### DIFF
--- a/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-nonprod.json
@@ -119,5 +119,18 @@
     "PostConditionState": "AwaitingReissue",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/petition-issued?generateAosInvitation=true",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "23/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "issueAosFromReissue",
+    "Name": "Issue AOS pack to respondent",
+    "Description": "Issue AOS pack to respondent",
+    "DisplayOrder": 1,
+    "PreConditionState(s)": "AwaitingReissue",
+    "PostConditionState": "AosAwaiting",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/bulk-print",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/aos-pack-issued",
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-prod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-prod.json
@@ -72,5 +72,20 @@
     "PostConditionState": "AosAwaiting",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/confirm-process-server-service",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE",
+    "ID": "issueAosFromReissue",
+    "Name": "Issue AOS pack to respondent",
+    "Description": "Issue AOS pack to respondent",
+    "DisplayOrder": 1,
+    "PreConditionState(s)": "AwaitingReissue",
+    "PostConditionState": "AosAwaiting",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/bulk-print",
+    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/petition-updated",
+    "RetriesTimeoutURLSubmittedEvent": "120,120",
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent.json
@@ -707,21 +707,6 @@
     "SecurityClassification": "Public"
   },
   {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "DIVORCE",
-    "ID": "issueAosFromReissue",
-    "Name": "Issue AOS pack to respondent",
-    "Description": "Issue AOS pack to respondent",
-    "DisplayOrder": 1,
-    "PreConditionState(s)": "AwaitingReissue",
-    "PostConditionState": "AosAwaiting",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/bulk-print",
-    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
-    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/petition-updated",
-    "RetriesTimeoutURLSubmittedEvent": "120,120",
-    "SecurityClassification": "Public"
-  },
-  {
     "LiveFrom": "02/01/2017",
     "CaseTypeID": "DIVORCE",
     "ID": "transferCaseFromCTSCreissue",
@@ -2737,7 +2722,7 @@
     "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/service-decision-made/final",
     "RetriesTimeoutURLSubmittedEvent": "120,120",
     "SecurityClassification": "Public",
-    "ShowSummary":  "Y"
+    "ShowSummary": "Y"
   },
   {
     "LiveFrom": "16/09/2020",


### PR DESCRIPTION
On prod for now `issueAosFromReissue.CallBackURLSubmittedEvent` stays unchanged.

Behind feature toggle it calls new endpoint.

Story:
https://tools.hmcts.net/jira/browse/DIV-6762

DO NOT MERGE until https://github.com/hmcts/div-case-orchestration-service/pull/1332 is merged.