### PR TITLE
DIV-6839 Transfer to CTSC from Service journey / Bailiff states

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-bailiff-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-bailiff-nonprod.json
@@ -306,5 +306,47 @@
     "CaseEventID": "coRespAnswerReceivedBailiff",
     "UserRole": "caseworker-divorce-courtadmin-la",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "29/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromCTSCService",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "29/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromCTSCService",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "29/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromCTSCService",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "29/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromCTSCService",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "29/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromCTSCService",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "29/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromCTSCService",
+    "UserRole": "citizen",
+    "CRUD": "R"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-nonprod.json
@@ -208,5 +208,16 @@
     "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
     "SecurityClassification": "Public",
     "ShowSummary": "Y"
+  },
+  {
+    "LiveFrom": "29/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "transferCaseFromCTSCService",
+    "Name": "Transfer from CTSC to RDC",
+    "Description": "Transfer from CTSC to an RDC",
+    "DisplayOrder": 11,
+    "PreConditionState(s)": "AwaitingBailiffReferral;AwaitingBailiffService;IssuedToBailiff;AwaitingServiceConsideration;AwaitingServicePayment;AwaitingGeneralReferralPayment;AwaitingGeneralConsideration;GeneralConsiderationComplete;DNPronounced",
+    "PostConditionState": "Issued",
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/divorce/json/CaseEventToFields/CaseEventToFields-bailiff-nonprod.json
+++ b/definitions/divorce/json/CaseEventToFields/CaseEventToFields-bailiff-nonprod.json
@@ -142,5 +142,16 @@
     "PageColumnNumber": 1,
     "FieldShowCondition": "DNApplyForDecreeNisi=\"nevershow\"",
     "ShowSummaryChangeOption": "No"
+  },
+  {
+    "LiveFrom": "29/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "transferCaseFromCTSCService",
+    "CaseFieldID": "D8DivorceUnit",
+    "DisplayContext": "MANDATORY",
+    "PageID": "Transfer Case",
+    "PageLabel": "Transfer Case",
+    "PageDisplayOrder": 1,
+    "PageColumnNumber": 1
   }
 ]


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DIV-6839

Acceptance criteria
```
Transfer from CTSC to RDC
GIVEN a case is in any of these states: AwaitingBailiffReferral;AwaitingBailifService;IssueToBailiff;AwaitingAOSBailiff;AwaitingService Consideration,AwaitingServicePayment,AwaitingGeneralApplicationPayment,AwaitingGeneralConsideration,GeneralConsiderationComplete;DNPronounced
THEN a caseworker can trigger the event 'Transfer from CTSC to RDC'
AND a screen appears where the user can select a value from the drop-down for D8DivorceUnit (see attached screenshots)
AND when the event is submitted state is changed to 'Issued'
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
