### PR TITLE
DIV-6228: Citizen respondent-co-respondent can submit AOS response whilst bailiff application in progress

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent-nonprod.json
@@ -40,5 +40,19 @@
     "CaseEventID": "testAosDrafted",
     "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "26/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "testIssuedToBailiff",
+    "UserRole": "citizen",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "26/02/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "testIssuedToBailiff",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-nonprod.json
@@ -21,5 +21,17 @@
     "PostConditionState": "AosDrafted",
     "RetriesTimeoutURLSubmittedEvent": "120,120",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "31/03/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "testIssuedToBailiff",
+    "Name": "Issued To Bailiff Test",
+    "Description": "TEST ONLY: Issued To Bailiff Test",
+    "DisplayOrder": 21,
+    "PreConditionState(s)": "*",
+    "PostConditionState": "IssuedToBailiff",
+    "RetriesTimeoutURLSubmittedEvent": "120,120",
+    "SecurityClassification": "Public"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DIV-6228


### Change description ###

Needed a test event to move a case to one of the bailiff related states to enable cover Integration test for the bailiff feature for when respondent/co-respondent AoS responses come in.

Test event added in `-nonprod` feature file and should not make it to prod.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
