### PR TITLE
DIV-6858: no permissions for CCA role on solicitorAwaitingPaymentConfirmation and Submitted states

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-share-a-case-nonprod.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState-share-a-case-nonprod.json
@@ -16,20 +16,6 @@
   {
     "LiveFrom": "26/03/2021",
     "CaseTypeID": "DIVORCE",
-    "CaseStateID": "Submitted",
-    "UserRole": "caseworker-caa",
-    "CRUD": "R"
-  },
-  {
-    "LiveFrom": "26/03/2021",
-    "CaseTypeID": "DIVORCE",
-    "CaseStateID": "solicitorAwaitingPaymentConfirmation",
-    "UserRole": "caseworker-caa",
-    "CRUD": "R"
-  },
-  {
-    "LiveFrom": "26/03/2021",
-    "CaseTypeID": "DIVORCE",
     "CaseStateID": "PendingRejection",
     "UserRole": "caseworker-caa",
     "CRUD": "CRU"


### PR DESCRIPTION
Story:
https://tools.hmcts.net/jira/browse/DIV-6858

Business requirements: when case is submitted (states: solicitorAwaitingPaymentConfirmation and Submitted) CAA must not see it on list of unassigned cases in manage-org.