### PR TITLE
DIV-6846 - Ability to trigger 'Service application received' prior to issue

### DIFF
--- a/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-or-resp-journey-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-or-resp-journey-nonprod.json
@@ -1,0 +1,15 @@
+[
+  {
+    "LiveFrom": "06/04/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "serviceApplicationReceived",
+    "Name": "Service application received",
+    "Description": "Service application received",
+    "DisplayOrder": 11,
+    "PreConditionState(s)": "AosStarted;AosOverdue;ServiceApplicationNotApproved;AosAwaiting;AosDrafted;Submitted;Issued;awaitingPetitionerSolicitorAwaitingPayConfirm",
+    "PostConditionState": "AwaitingServicePayment",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/received-service-added-date",
+    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
+    "SecurityClassification": "Public"
+  }
+]

--- a/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-or-resp-journey-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-or-resp-journey-nonprod.json
@@ -6,7 +6,7 @@
     "Name": "Service application received",
     "Description": "Service application received",
     "DisplayOrder": 11,
-    "PreConditionState(s)": "AosStarted;AosOverdue;ServiceApplicationNotApproved;AosAwaiting;AosDrafted;Submitted;Issued;awaitingPetitionerSolicitorAwaitingPayConfirm",
+    "PreConditionState(s)": "AosStarted;AosOverdue;ServiceApplicationNotApproved;AosAwaiting;AosDrafted;Submitted;Issued;AwaitingDocuments",
     "PostConditionState": "AwaitingServicePayment",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/received-service-added-date",
     "RetriesTimeoutURLAboutToSubmitEvent": "120,120",

--- a/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-resp-journey-nonprod.json
@@ -24,19 +24,6 @@
     "ShowSummary": "Y"
   },
   {
-    "LiveFrom": "23/07/2020",
-    "CaseTypeID": "DIVORCE",
-    "ID": "serviceApplicationReceived",
-    "Name": "Service application received",
-    "Description": "Service application received",
-    "DisplayOrder": 11,
-    "PreConditionState(s)": "AosStarted;AosOverdue;ServiceApplicationNotApproved;AosAwaiting;AosDrafted",
-    "PostConditionState": "AwaitingServicePayment",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/received-service-added-date",
-    "RetriesTimeoutURLAboutToSubmitEvent": "120,120",
-    "SecurityClassification": "Public"
-  },
-  {
     "LiveFrom": "26/02/2021",
     "CaseTypeID": "DIVORCE",
     "ID": "aosNotReceived",

--- a/test/unit/utils/dataProvider.js
+++ b/test/unit/utils/dataProvider.js
@@ -92,6 +92,7 @@ module.exports = {
     CaseEvent: getCaseEventDefinitions([
       'CaseEvent',
       'CaseEvent-bailiff-nonprod',
+      'CaseEvent-bailiff-or-resp-journey-nonprod',
       'CaseEvent-object-to-costs-nonprod',
       'CaseEvent-resp-journey-nonprod',
       'CaseEvent-share-a-case-nonprod',


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6846

### Change description ###

Adds `Submitted;Issued;AwaitingDocuments` to pre condition states of `serviceApplicationReceived`. To be released with bailiff or resp-journey release, whichever comes first

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
