### PR TITLE
DIV-6806 - Add 'Bailiff Certificate of Service' and 'Objection to Costs' document types

### DIFF
--- a/definitions/divorce/json/FixedLists/FixedLists-bailiff-nonprod.json
+++ b/definitions/divorce/json/FixedLists/FixedLists-bailiff-nonprod.json
@@ -10,5 +10,17 @@
     "ID": "d8documentsReceivedEnum",
     "ListElementCode": "certificateOfService",
     "ListElement": "Certificate Of Service"
+  },
+  {
+    "LiveFrom": "07/04/2021",
+    "ID": "d8documentsReceivedEnum",
+    "ListElementCode": "bailiffCertificateOfService",
+    "ListElement": "Bailiff Certificate of Service"
+  },
+  {
+    "LiveFrom": "07/04/2021",
+    "ID": "d8documentsReceivedEnum",
+    "ListElementCode": "objectionToCosts",
+    "ListElement": "Objection to Costs"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6806

### Change description ###

Adds the following document types:

- Bailiff Certificate of Service
- Objection to Costs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
