### PR TITLE
DIV-6847: fixed functional tests when PetitionerOrganisationPolicy is mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,4 @@ Run full E2E tests on CCD PR or AAT
 
 1) Configure defined env variables , env variables can be found in Azure divorce aat key vault.
 2) `yarn test:functional` will create cases via API (runs on PR and master AAT).
+

--- a/test/data/case-creation-basic-data.json
+++ b/test/data/case-creation-basic-data.json
@@ -125,5 +125,13 @@
   },
   "D8ReasonForDivorce": "unreasonable-behaviour",
   "D8DerivedPetitionerCurrentFullName": "Gary Ford",
-  "D8InferredPetitionerGender": "male"
+  "D8InferredPetitionerGender": "male",
+  "PetitionerOrganisationPolicy": {
+    "Organisation": {
+      "OrganisationID": "M2ZT9Q2",
+      "OrganisationName": "DivPetitionerSolicitorFirm"
+    },
+    "OrgPolicyReference": "DivPetitionerSolicitorFirm",
+    "OrgPolicyCaseAssignedRole": "[PETSOLICITOR]"
+  }
 }

--- a/test/data/case-creation-basic-data.json
+++ b/test/data/case-creation-basic-data.json
@@ -125,13 +125,5 @@
   },
   "D8ReasonForDivorce": "unreasonable-behaviour",
   "D8DerivedPetitionerCurrentFullName": "Gary Ford",
-  "D8InferredPetitionerGender": "male",
-  "PetitionerOrganisationPolicy": {
-    "Organisation": {
-      "OrganisationID": "M2ZT9Q2",
-      "OrganisationName": "DivPetitionerSolicitorFirm"
-    },
-    "OrgPolicyReference": "DivPetitionerSolicitorFirm",
-    "OrgPolicyCaseAssignedRole": "[PETSOLICITOR]"
-  }
+  "D8InferredPetitionerGender": "male"
 }

--- a/test/data/case-creation-solicitor.json
+++ b/test/data/case-creation-solicitor.json
@@ -1,0 +1,137 @@
+{
+  "D8DerivedRespondentHomeAddress": "24 Melville Road\nCoventry\nCV1 3AL",
+  "D8DerivedPetitionerHomeAddress": "24 Melville Road\nCoventry\nCV1 3AL",
+  "D8RespondentHomeAddress": {
+    "County": "",
+    "Country": "UK",
+    "PostCode": "CV1 3AL",
+    "PostTown": "COVENTRY",
+    "AddressLine1": "24 MELVILLE ROAD",
+    "AddressLine2": "",
+    "AddressLine3": ""
+  },
+  "D8ScreenHasRespondentAddress": "YES",
+  "D8DivorceCostsClaim": "NO",
+  "Payments": [
+    {
+      "id": "d41e0abe-912e-4a2d-a703-6a0ed5c6c676",
+      "value": {
+        "PaymentDate": "2018-11-02",
+        "PaymentFeeId": "FEE0002",
+        "PaymentAmount": "55000",
+        "PaymentSiteId": "AA04",
+        "PaymentStatus": "Success",
+        "PaymentChannel": "online",
+        "PaymentReference": "RC-1541-1597-6983-3821",
+        "PaymentTransactionId": "ge7po9h5bhbtbd466424src9tk"
+      }
+    }
+  ],
+  "D8ScreenHasMarriageCert": "YES",
+  "D8PetitionerHomeAddress": {
+    "County": "",
+    "Country": "UK",
+    "PostCode": "CV1 3AL",
+    "PostTown": "COVENTRY",
+    "AddressLine1": "24 MELVILLE ROAD",
+    "AddressLine2": "",
+    "AddressLine3": ""
+  },
+  "D8ScreenHasMarriageBroken": "YES",
+  "D8InferredRespondentGender": "female",
+  "D8ReasonForDivorceEnableAdultery": "YES",
+  "D8ReasonForDivorceShowAdultery": "YES",
+  "D8DerivedStatementOfCase": "dtfyjgkh\ndtfygh\ntfgkhl",
+  "D8LivingArrangementsLiveTogether": "YES",
+  "D8ReasonForDivorceHasMarriage": "YES",
+  "D8JurisdictionConfidentLegal": "YES",
+  "D8RespondentCorrespondenceUseHomeAddress": "Yes",
+  "D8Connections": {
+    "A": "The Petitioner and the Respondent are habitually resident in England and Wales",
+    "C": "The Respondent is habitually resident in England and Wales"
+  },
+  "D8PetitionerCorrespondenceAddress": {
+    "County": "",
+    "Country": "UK",
+    "PostCode": "CV1 3AL",
+    "PostTown": "COVENTRY",
+    "AddressLine1": "24 MELVILLE ROAD",
+    "AddressLine2": "",
+    "AddressLine3": ""
+  },
+  "D8RespondentLastName": "Ford",
+  "D8PetitionerNameDifferentToMarriageCert": "NO",
+  "D8JurisdictionConnection": [
+    "A",
+    "C"
+  ],
+  "D8PetitionerLastName": "Ford",
+  "D8PetitionerPhoneNumber": "01234567891",
+  "D8ReasonForDivorceShowTwoYearsSeparation": "YES",
+  "D8StatementOfTruth": "YES",
+  "D8PetitionerCorrespondenceUseHomeAddress": "YES",
+  "D8DerivedRespondentCurrentName": "Helen Ford",
+  "D8ReasonForDivorceLimitReasons": "NO",
+  "D8PetitionerEmail": "gary.ford@mailinator.com",
+  "D8ReasonForDivorceBehaviourDetails": "dtfyjgkh\ndtfygh\ntfgkhl",
+  "D8DivorceUnit": "serviceCentre",
+  "D8ReasonForDivorceShowDesertion": "YES",
+  "D8DerivedRespondentCorrespondenceAddr": "24 Melville Road\nCoventry\nCV1 3AL",
+  "D8MarriagePetitionerName": "Gary Ford",
+  "D8Cohort": "onlineSubmissionPrivateBeta",
+  "D8MarriageIsSameSexCouple": "NO",
+  "D8FinancialOrder": "NO",
+  "D8ReasonForDivorceShowFiveYearsSeparatio": "YES",
+  "D8MarriageDate": "2002-02-02",
+  "D8HelpWithFeesNeedHelp": "NO",
+  "D8JurisdictionRespondentResidence": "YES",
+  "D8DivorceWho": "wife",
+  "D8MarriageCanDivorce": "YES",
+  "D8RespondentFirstName": "Helen",
+  "D8ReasonForDivorceShowUnreasonableBehavi": "YES",
+  "D8DocumentsUploaded": [
+    {
+      "id": "7678fa8e-3681-4556-a77d-544520259fc2",
+      "value": {
+        "DocumentLink": {
+          "document_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/91af9dea-8d30-4c47-8bf2-6a00179e80ef",
+          "document_filename": "Screenshot 2018-11-01 at 12.13.40.png",
+          "document_binary_url": "http://dm-store-aat.service.core-compute-aat.internal/documents/91af9dea-8d30-4c47-8bf2-6a00179e80ef/binary"
+        },
+        "DocumentType": "other",
+        "DocumentComment": "",
+        "DocumentFileName": "Screenshot 2018-11-01 at 12.13.40.png",
+        "DocumentDateAdded": "2018-11-02",
+        "DocumentEmailContent": ""
+      }
+    }
+  ],
+  "D8DerivedPetitionerCorrespondenceAddr": "24 Melville Road\nCoventry\nCV1 3AL",
+  "D8JurisdictionPetitionerResidence": "YES",
+  "D8MarriedInUk": "YES",
+  "D8PetitionerFirstName": "Gary",
+  "D8MarriageRespondentName": "Helen Ford",
+  "D8PetitionerContactDetailsConfidential": "share",
+  "D8LegalProceedings": "NO",
+  "createdDate": "2019-11-02",
+  "D8RespondentCorrespondenceAddress": {
+    "County": "",
+    "Country": "UK",
+    "PostCode": "CV1 3AL",
+    "PostTown": "COVENTRY",
+    "AddressLine1": "24 MELVILLE ROAD",
+    "AddressLine2": "",
+    "AddressLine3": ""
+  },
+  "D8ReasonForDivorce": "unreasonable-behaviour",
+  "D8DerivedPetitionerCurrentFullName": "Gary Ford",
+  "D8InferredPetitionerGender": "male",
+  "PetitionerOrganisationPolicy": {
+    "Organisation": {
+      "OrganisationID": "M2ZT9Q2",
+      "OrganisationName": "DivPetitionerSolicitorFirm"
+    },
+    "OrgPolicyReference": "DivPetitionerSolicitorFirm",
+    "OrgPolicyCaseAssignedRole": "[PETSOLICITOR]"
+  }
+}

--- a/test/functional/caseCreation_test.js
+++ b/test/functional/caseCreation_test.js
@@ -17,7 +17,13 @@ Scenario('Case Creation By Caseworker', async I => {
 
 // <<TO-DO: case creation by solicitor can be done only on AAT not on PR level>
 Scenario('Case Creation By Solicitor', async I => {
-  const caseId = await createCaseInCcd(solicitorUserName, solicitorPassword, './test/data/case-creation-basic-data.json', 'DIVORCE', 'solicitorCreate');
+  const caseId = await createCaseInCcd(
+    solicitorUserName,
+    solicitorPassword,
+    './test/data/case-creation-solicitor.json',
+    'DIVORCE',
+    'solicitorCreate'
+  );
   // const paymentMade = await updateCaseInCcd(solicitorUserName, solicitorPassword, caseId, 'DIVORCE', 'solicitorStatementOfTruthPaySubmit', './test/data/case-creation-basic-data.json');
  //  const issue = await updateCaseInCcd(caseWorkerUserName, caseWorkerPassword, caseId, 'DIVORCE', 'issueFromSubmitted', './test/data/case-issue-data.json');
 });


### PR DESCRIPTION
After making PetitionerOrganisationPolicy a mandatory field in the callback we must update test data.

Secret:
```
ccd-e2e-solicitor-email = divorce_as_petitioner_solicitor_02@mailinator.com
```

in preview and aat.

Story:
https://tools.hmcts.net/jira/browse/DIV-6847