### PR TITLE
DIV-6852: Split creation and removal of Add Bailiff return

### DIFF
--- a/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-nonprod.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent-bailiff-nonprod.json
@@ -9,6 +9,7 @@
     "PreConditionState(s)": "IssuedToBailiff",
     "PostConditionState": "AosAwaiting",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/add-bailiff-return",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/purge-bailiff-data",
     "SecurityClassification": "Public"
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6852

### Change description ###

![Screenshot 2021-04-12 at 12 25 12](https://user-images.githubusercontent.com/30896346/114387277-2399b480-9b8a-11eb-8a8d-3f509e8d018f.png)

This PR is trying to split (in COS)
`     log.info("CaseID: {}. Adding bailiff service application data task", caseId);
        tasks.add(bailiffServiceApplicationDataTask);
        log.info("CaseID: {}. Adding bailiff service application removal task", caseId);
        tasks.add(bailiffServiceApplicationRemovalTask);
`

I believe this lead to the issue above. Therefore i split it into 
`"CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/add-bailiff-return",
    "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/purge-bailiff-data",`

Where the `/purge-bailiff-data` has the `tasks.add(bailiffServiceApplicationRemovalTask);`
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
