### PR TITLE
RPET-991/RPET-984/inc 5198250: add idam roles permissions for states until case is submitted

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -364,7 +364,6 @@
     "UserRole": "[PETSOLICITOR]",
     "CRUD": "CRU"
   },
-
   {
     "LiveFrom": "12/05/2021",
     "CaseTypeID": "DIVORCE",

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -151,7 +151,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingDocuments",
     "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -168,11 +168,11 @@
     "CRUD": "CRU"
   },
   {
-    "LiveFrom": "01/01/2017",
+    "LiveFrom": "13/05/2021",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingHWFDecision",
     "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -151,7 +151,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingDocuments",
     "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "R"
+    "CRUD": "RU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -209,7 +209,6 @@
     "UserRole": "[PETSOLICITOR]",
     "CRUD": "R"
   },
-
   {
     "LiveFrom": "12/05/2021",
     "CaseTypeID": "DIVORCE",

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -209,6 +209,14 @@
     "UserRole": "[PETSOLICITOR]",
     "CRUD": "R"
   },
+
+  {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AwaitingPayment",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
@@ -294,6 +302,13 @@
     "CRUD": "RU"
   },
   {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "Issued",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "RU"
+  },
+  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "Issued",
@@ -349,6 +364,14 @@
     "UserRole": "[PETSOLICITOR]",
     "CRUD": "CRU"
   },
+
+  {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "solicitorAwaitingPaymentConfirmation",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "CRU"
+  },
   {
     "LiveFrom": "28/04/2021",
     "CaseTypeID": "DIVORCE",
@@ -361,6 +384,13 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "SOTAgreementPayAndSubmitRequired",
     "UserRole": "[PETSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "SOTAgreementPayAndSubmitRequired",
+    "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "CRU"
   },
   {
@@ -382,6 +412,13 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "Submitted",
     "UserRole": "[PETSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "Submitted",
+    "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "CRU"
   },
   {
@@ -1943,6 +1980,13 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingService",
     "UserRole": "[PETSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AwaitingService",
+    "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "CRU"
   },
   {

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -147,7 +147,7 @@
     "CRUD": "CRU"
   },
   {
-    "LiveFrom": "01/01/2017",
+    "LiveFrom": "13/05/2021",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingDocuments",
     "UserRole": "caseworker-divorce-solicitor",


### PR DESCRIPTION
See https://github.com/hmcts/div-ccd-definitions/pull/858

Story:
https://tools.hmcts.net/jira/browse/RPET-991

States (from story: https://tools.hmcts.net/jira/browse/RPET-979):
- SOTAgreementPayAndSubmitRequired
- AwaitingHWFDecision
- AwaitingService
- Submitted
- solicitorAwaitingPaymentConfirmation
- AwaitingPayment
- AwaitingDocuments
- Issued

In terms of `AwaitingHWFDecision` we already have it:
```
{
    "LiveFrom": "01/01/2017",
    "CaseTypeID": "DIVORCE",
    "CaseStateID": "AwaitingHWFDecision",
    "UserRole": "caseworker-divorce-solicitor",
    "CRUD": "RU"
  },
```

Notes:
```
  {
    "LiveFrom": "12/05/2021",
    "CaseTypeID": "DIVORCE",
    "CaseStateID": "AwaitingPayment",
    "UserRole": "caseworker-divorce-solicitor",
    "CRUD": "R"
  },
```

it's just R, and not CRU, because it's also just `R` for `[PETSOLICITOR]`.