### PR TITLE
RPET-991: Update DIV state permissions for CAA role

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -364,7 +364,6 @@
     "UserRole": "[PETSOLICITOR]",
     "CRUD": "CRU"
   },
-
   {
     "LiveFrom": "12/05/2021",
     "CaseTypeID": "DIVORCE",

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -151,7 +151,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingDocuments",
     "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -168,11 +168,11 @@
     "CRUD": "CRU"
   },
   {
-    "LiveFrom": "01/01/2017",
+    "LiveFrom": "13/05/2021",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingHWFDecision",
     "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "RU"
+    "CRUD": "CRU"
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -151,7 +151,7 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingDocuments",
     "UserRole": "caseworker-divorce-solicitor",
-    "CRUD": "R"
+    "CRUD": "RU"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -209,7 +209,6 @@
     "UserRole": "[PETSOLICITOR]",
     "CRUD": "R"
   },
-
   {
     "LiveFrom": "12/05/2021",
     "CaseTypeID": "DIVORCE",

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -209,6 +209,14 @@
     "UserRole": "[PETSOLICITOR]",
     "CRUD": "R"
   },
+
+  {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AwaitingPayment",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "R"
+  },
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
@@ -294,6 +302,13 @@
     "CRUD": "RU"
   },
   {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "Issued",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "RU"
+  },
+  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "Issued",
@@ -349,6 +364,14 @@
     "UserRole": "[PETSOLICITOR]",
     "CRUD": "CRU"
   },
+
+  {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "solicitorAwaitingPaymentConfirmation",
+    "UserRole": "caseworker-divorce-solicitor",
+    "CRUD": "CRU"
+  },
   {
     "LiveFrom": "28/04/2021",
     "CaseTypeID": "DIVORCE",
@@ -361,6 +384,13 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "SOTAgreementPayAndSubmitRequired",
     "UserRole": "[PETSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "SOTAgreementPayAndSubmitRequired",
+    "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "CRU"
   },
   {
@@ -382,6 +412,13 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "Submitted",
     "UserRole": "[PETSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "Submitted",
+    "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "CRU"
   },
   {
@@ -1943,6 +1980,13 @@
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingService",
     "UserRole": "[PETSOLICITOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "12/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseStateID": "AwaitingService",
+    "UserRole": "caseworker-divorce-solicitor",
     "CRUD": "CRU"
   },
   {

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -3236,13 +3236,6 @@
   {
     "LiveFrom": "26/03/2021",
     "CaseTypeID": "DIVORCE",
-    "CaseStateID": "SOTAgreementPayAndSubmitRequired",
-    "UserRole": "caseworker-caa",
-    "CRUD": "CRU"
-  },
-  {
-    "LiveFrom": "26/03/2021",
-    "CaseTypeID": "DIVORCE",
     "CaseStateID": "PendingRejection",
     "UserRole": "caseworker-caa",
     "CRUD": "CRU"
@@ -3432,13 +3425,6 @@
   {
     "LiveFrom": "26/03/2021",
     "CaseTypeID": "DIVORCE",
-    "CaseStateID": "AwaitingService",
-    "UserRole": "caseworker-caa",
-    "CRUD": "CRU"
-  },
-  {
-    "LiveFrom": "26/03/2021",
-    "CaseTypeID": "DIVORCE",
     "CaseStateID": "ClarificationSubmitted",
     "UserRole": "caseworker-caa",
     "CRUD": "CRU"
@@ -3545,49 +3531,6 @@
     "LiveFrom": "26/03/2021",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "GeneralConsiderationComplete",
-    "UserRole": "caseworker-caa",
-    "CRUD": "CRU"
-  }
-,
-  {
-    "LiveFrom": "12/04/2021",
-    "CaseTypeID": "DIVORCE",
-    "CaseStateID": "Submitted",
-    "UserRole": "caseworker-caa",
-    "CRUD": "CRU"
-  },
-  {
-    "LiveFrom": "12/04/2021",
-    "CaseTypeID": "DIVORCE",
-    "CaseStateID": "solicitorAwaitingPaymentConfirmation",
-    "UserRole": "caseworker-caa",
-    "CRUD": "CRU"
-  },
-  {
-    "LiveFrom": "12/04/2021",
-    "CaseTypeID": "DIVORCE",
-    "CaseStateID": "AwaitingPayment",
-    "UserRole": "caseworker-caa",
-    "CRUD": "CRU"
-  },
-  {
-    "LiveFrom": "12/04/2021",
-    "CaseTypeID": "DIVORCE",
-    "CaseStateID": "AwaitingDocuments",
-    "UserRole": "caseworker-caa",
-    "CRUD": "CRU"
-  },
-  {
-    "LiveFrom": "12/04/2021",
-    "CaseTypeID": "DIVORCE",
-    "CaseStateID": "AwaitingHWFDecision",
-    "UserRole": "caseworker-caa",
-    "CRUD": "CRU"
-  },
-  {
-    "LiveFrom": "12/04/2021",
-    "CaseTypeID": "DIVORCE",
-    "CaseStateID": "Issued",
     "UserRole": "caseworker-caa",
     "CRUD": "CRU"
   },

--- a/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/definitions/divorce/json/AuthorisationCaseState/AuthorisationCaseState.json
@@ -147,7 +147,7 @@
     "CRUD": "CRU"
   },
   {
-    "LiveFrom": "01/01/2017",
+    "LiveFrom": "13/05/2021",
     "CaseTypeID": "DIVORCE",
     "CaseStateID": "AwaitingDocuments",
     "UserRole": "caseworker-divorce-solicitor",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RPET-991

PRs:
https://github.com/hmcts/cnp-flux-config/pull/9730
https://github.com/hmcts/div-case-orchestration-service/pull/1427


Story:
https://tools.hmcts.net/jira/browse/RPET-991

States (from story: https://tools.hmcts.net/jira/browse/RPET-979):
- SOTAgreementPayAndSubmitRequired
- AwaitingHWFDecision
- AwaitingService
- Submitted
- solicitorAwaitingPaymentConfirmation
- AwaitingPayment
- AwaitingDocuments
- Issued

In terms of `AwaitingHWFDecision` we already have it:
```
{
    "LiveFrom": "01/01/2017",
    "CaseTypeID": "DIVORCE",
    "CaseStateID": "AwaitingHWFDecision",
    "UserRole": "caseworker-divorce-solicitor",
    "CRUD": "RU"
  },
```

Notes:
```
  {
    "LiveFrom": "12/05/2021",
    "CaseTypeID": "DIVORCE",
    "CaseStateID": "AwaitingPayment",
    "UserRole": "caseworker-divorce-solicitor",
    "CRUD": "R"
  },
```

it's just R, and not CRU, because it's also just `R` for `[PETSOLICITOR]`.