### PR TITLE
RPET-1007: Adding CRU permissions to [CREATOR] for events that should be triggered by [PETSOLICITOR]

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/divorce/json/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -9112,5 +9112,54 @@
     "CaseEventID": "judgeCostOrderDecision",
     "UserRole": "citizen",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "19/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solConfirmPersonalService",
+    "UserRole": "[CREATOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "19/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorApplyForDN",
+    "UserRole": "[CREATOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "19/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorUpdateDN",
+    "UserRole": "[CREATOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "19/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solicitorSOTDN",
+    "UserRole": "[CREATOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "19/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "solApplyForDA",
+    "UserRole": "[CREATOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "19/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "submitDnClarification",
+    "UserRole": "[CREATOR]",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "19/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseEventID": "amendPetitionForRefusalSol",
+    "UserRole": "[CREATOR]",
+    "CRUD": "CRU"
   }
 ]


### PR DESCRIPTION
Story:
https://tools.hmcts.net/jira/browse/RPET-1007

The behaviour was defined in:
https://tools.hmcts.net/jira/browse/DIV-6713

But there is a number of cases where petitioner solicitor created a case before Share a Case was released and submitted it after Share a Case was released.

Because data model has changed they were recognised as pet solicitors who don't want to be digital and Share a Case call to ACA api was not executed so that they didn't get [PETSOLICITOR] case role, but they still had [CREATOR] case role and caseworker-divorce-solicitor idam role so it was invisible for them until event "solApplyForDA".

In DIV-6713 there are also other events only [PETSOLICITOR] can trigger:
```
solConfirmPersonalService
solicitorApplyForDN
solicitorUpdateDN
solicitorSOTDN
solApplyForDA
submitDnClarification
amendPetitionForRefusalSol
```

To fix it we should also grant the same set of permissions to [CREATOR] case role.

Impact:
- for properly created cases with Share a Case - no impact (they have [PETSOLICITOR] case role and [CREATOR] case role is removed - as required by CCD)
- for cases that were created before Share a Case and submitted before Share case - nothing (they have [PETSOLICITOR] case role given in the old way
- for cases that were created before SaC and submitted after SaC was released - fixed, petitioner solicitor will not have [PETSOLICITOR] case role, but will be able to finish off journey using idam solicitor role and [CREATOR] case role that was not removed from them.
