### PR TITLE
RPET-966 persist general email

### DIFF
--- a/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/divorce/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -23471,5 +23471,33 @@
     "CaseFieldID": "dueDate",
     "UserRole": "caseworker-caa",
     "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "GeneralEmailDetailsCollection",
+    "UserRole": "caseworker-divorce-courtadmin",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "GeneralEmailDetailsCollection",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "GeneralEmailDetailsCollection",
+    "UserRole": "caseworker-divorce-courtadmin-la",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "CaseFieldID": "GeneralEmailDetailsCollection",
+    "UserRole": "caseworker-divorce-superuser",
+    "CRUD": "CRU"
   }
 ]

--- a/definitions/divorce/json/CaseEvent/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent.json
@@ -2982,6 +2982,7 @@
     "DisplayOrder": 15,
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_COS_URL}/create-general-email/clear-fields",
     "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/create-general-email",
     "ShowSummary": "Y",
     "SecurityClassification": "Public"

--- a/definitions/divorce/json/CaseEvent/CaseEvent.json
+++ b/definitions/divorce/json/CaseEvent/CaseEvent.json
@@ -2983,6 +2983,7 @@
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "CallBackURLAboutToStartEvent": "${CCD_DEF_COS_URL}/create-general-email/clear-fields",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/create-general-email/store-fields",
     "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/create-general-email",
     "ShowSummary": "Y",
     "SecurityClassification": "Public"

--- a/definitions/divorce/json/CaseField/CaseField.json
+++ b/definitions/divorce/json/CaseField/CaseField.json
@@ -5114,7 +5114,7 @@
     "LiveFrom": "08/09/2020",
     "CaseTypeID": "DIVORCE",
     "ID": "GeneralEmailDateTime",
-    "Label": "General letter date",
+    "Label": "General email date",
     "FieldType": "Date",
     "SecurityClassification": "Public"
   },
@@ -5149,6 +5149,15 @@
     "ID": "GeneralEmailDetails",
     "Label": "Please provide details",
     "FieldType": "TextArea",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "ID": "GeneralEmailDetails",
+    "Label": "General emails",
+    "FieldType": "Collection",
+    "FieldTypeParameter": "GeneralEmailDetails",
     "SecurityClassification": "Public"
   },
   {

--- a/definitions/divorce/json/CaseField/CaseField.json
+++ b/definitions/divorce/json/CaseField/CaseField.json
@@ -5154,7 +5154,7 @@
   {
     "LiveFrom": "20/05/2021",
     "CaseTypeID": "DIVORCE",
-    "ID": "GeneralEmailDetails",
+    "ID": "GeneralEmailDetailsCollection",
     "Label": "General emails",
     "FieldType": "Collection",
     "FieldTypeParameter": "GeneralEmailDetails",

--- a/definitions/divorce/json/CaseTypeTab/CaseTypeTab.json
+++ b/definitions/divorce/json/CaseTypeTab/CaseTypeTab.json
@@ -2985,6 +2985,16 @@
     "TabFieldDisplayOrder": 8
   },
   {
+    "LiveFrom": "21/05/2021",
+    "CaseTypeID": "DIVORCE",
+    "Channel": "CaseWorker",
+    "TabID": "documents",
+    "TabLabel": "Documents",
+    "TabDisplayOrder": 36,
+    "CaseFieldID": "GeneralEmailDetailsCollection",
+    "TabFieldDisplayOrder": 9
+  },
+  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE",
     "Channel": "CaseWorker",

--- a/definitions/divorce/json/ComplexTypes/ComplexTypes.json
+++ b/definitions/divorce/json/ComplexTypes/ComplexTypes.json
@@ -698,7 +698,7 @@
     "LiveFrom": "20/05/2021",
     "ID": "GeneralEmailDetails",
     "ListElementCode": "GeneralEmailDateTime",
-    "FieldType": "Date",
+    "FieldType": "DateTime",
     "ElementLabel": "General email date",
     "SecurityClassification": "Public"
   },

--- a/definitions/divorce/json/ComplexTypes/ComplexTypes.json
+++ b/definitions/divorce/json/ComplexTypes/ComplexTypes.json
@@ -693,5 +693,54 @@
     "FieldType": "TextArea",
     "ElementLabel": "Reason for failure to serve",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "ID": "GeneralEmailDetails",
+    "ListElementCode": "GeneralEmailDateTime",
+    "FieldType": "Date",
+    "ElementLabel": "General email date",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "ID": "GeneralEmailDetails",
+    "ListElementCode": "GeneralEmailParties",
+    "FieldType": "FixedList",
+    "FieldTypeParameter": "GeneralPartiesEnum",
+    "ElementLabel": "Address to",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "ID": "GeneralEmailDetails",
+    "ListElementCode": "GeneralEmailOtherRecipientEmail",
+    "FieldType": "Email",
+    "ElementLabel": "Recipient's email",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "ID": "GeneralEmailDetails",
+    "ListElementCode": "GeneralEmailOtherRecipientName",
+    "FieldType": "Text",
+    "ElementLabel": "Recipient's name",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "ID": "GeneralEmailDetails",
+    "ListElementCode": "GeneralEmailCreatedBy",
+    "FieldType": "Text",
+    "ElementLabel": "Email created by",
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "20/05/2021",
+    "ID": "GeneralEmailDetails",
+    "ListElementCode": "GeneralEmailBody",
+    "FieldType": "TextArea",
+    "ElementLabel": "Body",
+    "SecurityClassification": "Public"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -19,11 +19,7 @@
       "ccdUrl": "http://ccd-data-store-api-demo.service.core-compute-demo.internal"
     },
     "aat": {
-      "cosUrl": "http://div-cos-pr-1432.service.core-compute-preview.internal",
-      "ccdUrl": "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
-    },
-    "preview": {
-      "cosUrl": "http://div-cos-pr-1432.service.core-compute-preview.internal",
+      "cosUrl": "http://div-cos-aat.service.core-compute-aat.internal",
       "ccdUrl": "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     },
     "perftest": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
       "ccdUrl": "http://ccd-data-store-api-demo.service.core-compute-demo.internal"
     },
     "aat": {
-      "cosUrl": "http://div-cos-aat.service.core-compute-aat.internal",
+      "cosUrl": "http://div-cos-pr-1432.service.core-compute-preview.internal",
+      "ccdUrl": "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
+    },
+    "preview": {
+      "cosUrl": "http://div-cos-pr-1432.service.core-compute-preview.internal",
       "ccdUrl": "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     },
     "perftest": {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPET-966

### Change description ###

For existing general email functionality added:
- clearing CCD fields used for general email when the event is invoked 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
